### PR TITLE
having issue with literal value as subflow input

### DIFF
--- a/definition/definition_ser.go
+++ b/definition/definition_ser.go
@@ -245,6 +245,9 @@ func createActivityConfig(task *Task, rep *activity.Config, ef expression.Factor
 					return nil, fmt.Errorf("convert value [%+v] to type [%s] error: %s", v, fieldMetaddata.Type(), err.Error())
 				}
 				input[k] = v
+			} else {
+				//For the cases that metadata comes from iometadata, eg: subflow
+				input[k] = v
 			}
 		} else {
 			input[k] = v
@@ -267,7 +270,10 @@ func createActivityConfig(task *Task, rep *activity.Config, ef expression.Factor
 					return nil, fmt.Errorf("convert value [%+v] to type [%s] error: %s", v, fieldMetaddata.Type(), err.Error())
 				}
 				output[k] = v
+			} else {
+				output[k] = v
 			}
+
 		} else {
 			output[k] = v
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
 The literal value in subflow activity input which got lost.
**What is the new behavior?**
Because of subflow metadata comes from io metadata which cannot know when init flow.
