### PR TITLE
Added additional data in flow and task event

### DIFF
--- a/instance/taskevents.go
+++ b/instance/taskevents.go
@@ -17,7 +17,7 @@ type taskEvent struct {
 }
 
 // Returns activity ref
-func (te *taskEvent) Ref() string {
+func (te *taskEvent) ActivityRef() string {
 	return te.ref
 }
 

--- a/instance/taskevents.go
+++ b/instance/taskevents.go
@@ -9,11 +9,16 @@ import (
 )
 
 type taskEvent struct {
-	time                           time.Time
-	err                            error
-	taskIn, taskOut                map[string]interface{}
-	status                         event.Status
-	name, typeId, flowName, flowId string
+	time                                time.Time
+	err                                 error
+	taskIn, taskOut                     map[string]interface{}
+	status                              event.Status
+	name, typeId, flowName, flowId, ref string
+}
+
+// Returns activity ref
+func (te *taskEvent) Ref() string {
+	return te.ref
 }
 
 // Returns flow name
@@ -91,6 +96,10 @@ func postTaskEvent(taskInstance *TaskInst) {
 		te.flowName = taskInstance.flowInst.Name()
 		te.flowId = taskInstance.flowInst.ID()
 		te.typeId = taskInstance.Task().TypeID()
+
+		if taskInstance.HasActivity() {
+			te.ref = taskInstance.Task().ActivityConfig().Ref()
+		}
 
 		if te.status == event.FAILED {
 			te.err = taskInstance.returnError

--- a/support/event/flowevents.go
+++ b/support/event/flowevents.go
@@ -27,12 +27,6 @@ type FlowEvent interface {
 	FlowName() string
 	// Returns flow ID
 	FlowID() string
-	// In case of subflow, returns parent flow name
-	ParentFlowName() string
-	// In case of subflow, returns parent flow ID
-	ParentFlowID() string
-	// Returns event time
-	Time() time.Time
 	// Returns current flow status
 	FlowStatus() Status
 	// Returns input data for flow instance
@@ -41,10 +35,20 @@ type FlowEvent interface {
 	FlowOutput() map[string]interface{}
 	// Returns error for failed flow instance
 	FlowError() error
+	// Returns name of activity calling this flow in case of subflow invocation
+	HostName() string
+	// In case of subflow, returns parent flow name
+	ParentFlowName() string
+	// In case of subflow, returns parent flow ID
+	ParentFlowID() string
+	// Returns event time
+	Time() time.Time
 }
 
 // TaskEvent provides access to task instance execution details
 type TaskEvent interface {
+	// Returns activity ref
+	ActivityRef() string
 	// Returns flow name
 	FlowName() string
 	// Returns flow ID


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today, there is no way to get activity ref as well as name of sub-flow activity that is invoking flow.
**What is the new behavior?**
Added these two details in flow and task events so that collectors can use them in their implementation.
e.g. In oder to create sub-flow as a child span in open tracing,  we need to know span of sub-flow activity from parent flow. Also, we need to know when this relationship to be established. Using activity name and ref, we can easily achieve it.