### PR TITLE
Propagating trigger Go context to flow instance

### DIFF
--- a/action.go
+++ b/action.go
@@ -217,6 +217,8 @@ func (fa *FlowAction) Run(context context.Context, inputs map[string]interface{}
 		if err != nil {
 			return err
 		}
+		// Set trigger context in process instance for propagation
+		_ = inst.SetValue("_triggerContext", context)
 	case instance.OpResume:
 		if initialState != nil {
 			inst = initialState

--- a/instance/flowevents.go
+++ b/instance/flowevents.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"time"
 
 	coreevent "github.com/project-flogo/core/engine/event"
@@ -10,6 +11,7 @@ import (
 
 type flowEvent struct {
 	time                                     time.Time
+	tContext                                 context.Context
 	err                                      error
 	input, output                            map[string]interface{}
 	status                                   event.Status
@@ -38,6 +40,11 @@ func (fe *flowEvent) ParentFlowID() string {
 // Returns event time
 func (fe *flowEvent) Time() time.Time {
 	return fe.time
+}
+
+// Returns trigger context
+func (fe *flowEvent) TriggerContext() context.Context {
+	return fe.tContext
 }
 
 // Returns current flow status
@@ -76,6 +83,11 @@ func postFlowEvent(inst *Instance) {
 		if inst.master != nil && inst.master.id != inst.ID() {
 			fe.parentName = inst.master.Name()
 			fe.parentId = inst.master.ID()
+		}
+
+		tContext, found := inst.GetValue("_triggerContext")
+		if found {
+			fe.tContext = tContext.(context.Context)
 		}
 
 		taskInst, ok := inst.host.(*TaskInst)

--- a/support/event/flowevents.go
+++ b/support/event/flowevents.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"context"
 	"time"
 )
 
@@ -43,6 +44,8 @@ type FlowEvent interface {
 	ParentFlowID() string
 	// Returns event time
 	Time() time.Time
+	//Returns Trigger context set by the trigger
+	TriggerContext() context.Context
 }
 
 // TaskEvent provides access to task instance execution details


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently, triggers can not propagate details to flow instances. e.g. tracing span  which flows would join etc
**What is the new behavior?**
With this fix, Go context set by the trigger can be propagated to flow instances and then to event listeners who then can use details from the context for correlation. e.g. OpenTracing listener may want flow instance to join a span retrieved from trigger as a child.
