### PR TITLE
Propagating Tracing context set by trigger to Flow Event

### DIFF
--- a/instance/flowevents.go
+++ b/instance/flowevents.go
@@ -10,6 +10,7 @@ import (
 
 type flowEvent struct {
 	time                                     time.Time
+	tContext                                 interface{}
 	err                                      error
 	input, output                            map[string]interface{}
 	status                                   event.Status
@@ -38,6 +39,11 @@ func (fe *flowEvent) ParentFlowID() string {
 // Returns event time
 func (fe *flowEvent) Time() time.Time {
 	return fe.time
+}
+
+// Returns tracing context set by trigger
+func (fe *flowEvent) TracingContext() interface{} {
+	return fe.tContext
 }
 
 // Returns current flow status
@@ -84,6 +90,7 @@ func postFlowEvent(inst *Instance) {
 		}
 
 		fe.status = convertFlowStatus(inst.Status())
+		fe.tContext = inst.TracingContext()
 
 		fe.input = make(map[string]interface{})
 		fe.output = make(map[string]interface{})

--- a/support/event/flowevents.go
+++ b/support/event/flowevents.go
@@ -43,6 +43,8 @@ type FlowEvent interface {
 	ParentFlowID() string
 	// Returns event time
 	Time() time.Time
+	// Returns tracing context set by the trigger
+	TracingContext() interface{}
 }
 
 // TaskEvent provides access to task instance execution details


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
The tracing context is set in the flow instance but not propagated to event listeners. Hence, event listeners not able to correlate spans.
**What is the new behavior?**
Now, event listeners can access tracing context from the flow event for correlation. 