### PR TITLE
Set unique task instance id and exposed it through TaskEvent

### DIFF
--- a/instance/instances.go
+++ b/instance/instances.go
@@ -485,6 +485,8 @@ func (inst *IndependentInstance) enterTasks(activeInst *Instance, taskEntries []
 		taskToEnterBehavior := inst.flowModel.GetTaskBehavior(taskEntry.Task.TypeID())
 
 		enterTaskData, _ := activeInst.FindOrCreateTaskData(taskEntry.Task)
+		// Increment task instance id counter
+		enterTaskData.id++
 
 		enterResult := taskToEnterBehavior.Enter(enterTaskData)
 

--- a/instance/taskevents.go
+++ b/instance/taskevents.go
@@ -10,6 +10,7 @@ import (
 
 type taskEvent struct {
 	time                                time.Time
+	id                                  int
 	err                                 error
 	taskIn, taskOut                     map[string]interface{}
 	status                              event.Status
@@ -34,6 +35,11 @@ func (te *taskEvent) FlowID() string {
 // Returns task name
 func (te *taskEvent) TaskName() string {
 	return te.name
+}
+
+// Returns task instance id
+func (te *taskEvent) TaskInstanceId() int {
+	return te.id
 }
 
 // Returns task type
@@ -96,6 +102,7 @@ func postTaskEvent(taskInstance *TaskInst) {
 		te.flowName = taskInstance.flowInst.Name()
 		te.flowId = taskInstance.flowInst.ID()
 		te.typeId = taskInstance.Task().TypeID()
+		te.id = taskInstance.id
 
 		if taskInstance.HasActivity() {
 			te.ref = taskInstance.Task().ActivityConfig().Ref()

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -34,6 +34,7 @@ type TaskInst struct {
 	flowInst *Instance
 	task     *definition.Task
 	status   model.TaskStatus
+	id       int
 
 	workingData *WorkingDataScope
 
@@ -58,6 +59,11 @@ func (ti *TaskInst) ActivityHost() activity.Host {
 // Name implements activity.Context.Name method
 func (ti *TaskInst) Name() string {
 	return ti.task.Name()
+}
+
+// Returns task instance id
+func (ti *TaskInst) Id() int {
+	return ti.id
 }
 
 // GetInput implements activity.Context.GetInput


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today, when task is running loop (e.g. iterator), there is no way to identify unique task instance.
**What is the new behavior?**
Added counter that increments on every new execution of same task and exposed that over TaskEvent. 