### PR TITLE
Fix retry data

### DIFF
--- a/model/simple/retry.go
+++ b/model/simple/retry.go
@@ -24,7 +24,7 @@ func getRetryData(ctx model.TaskContext) (retryData *RetryData, err error) {
 		// first attempt - build retry data
 		retryData := &RetryData{}
 		if ctx.Task().LoopConfig() != nil && ctx.Task().LoopConfig().EnabledRetryOnError() {
-			retryData.Count =  ctx.Task().LoopConfig().RetryOnErrorCount()
+			retryData.Count = ctx.Task().LoopConfig().RetryOnErrorCount()
 			retryData.Interval = ctx.Task().LoopConfig().RetryOnErrorInterval()
 			ctx.SetWorkingData(retryOnErrorAttr, retryData)
 		}

--- a/model/simple/retry.go
+++ b/model/simple/retry.go
@@ -22,14 +22,13 @@ type RetryData struct {
 func getRetryData(ctx model.TaskContext) (retryData *RetryData, err error) {
 	if _, ok := ctx.GetWorkingData(retryOnErrorAttr); !ok {
 		// first attempt - build retry data
+		retryData := &RetryData{}
 		if ctx.Task().LoopConfig() != nil && ctx.Task().LoopConfig().EnabledRetryOnError() {
-			retryData := &RetryData{
-				Count:    ctx.Task().LoopConfig().RetryOnErrorCount(),
-				Interval: ctx.Task().LoopConfig().RetryOnErrorInterval(),
-			}
+			retryData.Count =  ctx.Task().LoopConfig().RetryOnErrorCount()
+			retryData.Interval = ctx.Task().LoopConfig().RetryOnErrorInterval()
 			ctx.SetWorkingData(retryOnErrorAttr, retryData)
-			return retryData, nil
 		}
+		return retryData, nil
 	}
 	// should be set by now
 	rd, _ := ctx.GetWorkingData(retryOnErrorAttr)

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -117,9 +117,6 @@ func evalActivity(ctx model.TaskContext) (bool, error) {
 				return retryEval(ctx, retryData)
 			}
 		}
-		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
-		ctx.FlowLogger().Errorf("Error evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
-		ctx.SetStatus(model.TaskStatusFailed)
 		return done, err
 	}
 	return done, nil

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -113,7 +113,7 @@ func evalActivity(ctx model.TaskContext) (bool, error) {
 			if rerr != nil {
 				return done, rerr
 			}
-			if retryData.Count > 0 {
+			if retryData != nil && retryData.Count > 0 {
 				return retryEval(ctx, retryData)
 			}
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
When an activity is not configured with retry, `getRetryData()` returned `error getting retry data`.
Error gets repeated at evalActivity()
**What is the new behavior?**
1. Activity that throws a `RetriableError` but is not configured with retryOnError will not throw `error getting retry data` and activity is not retried on error.
2. Unnecessary duplication of error printing is removed from evalActivity()
