### PR TITLE
fix for unique task-id

### DIFF
--- a/instance/instances.go
+++ b/instance/instances.go
@@ -210,10 +210,6 @@ func (inst *IndependentInstance) scheduleEval(taskInst *TaskInst) {
 
 	inst.wiCounter++
 
-	// Increment task instance id counter
-	taskInst.counter++
-	taskInst.id = taskInst.taskID + "-" + strconv.Itoa(taskInst.counter)
-
 	workItem := NewWorkItem(inst.wiCounter, taskInst)
 	inst.logger.Debugf("Scheduling task '%s'", taskInst.task.ID())
 
@@ -275,6 +271,8 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 		taskInst.SetStatus(model.TaskStatusFailed)
 	case model.EvalRepeat:
 		taskInst.SetStatus(model.TaskStatusReady)
+		taskInst.counter++
+		taskInst.id = taskInst.taskID + "-" + strconv.Itoa(taskInst.counter)
 		//task needs to iterate or retry
 		inst.scheduleEval(taskInst)
 	}
@@ -491,6 +489,7 @@ func (inst *IndependentInstance) enterTasks(activeInst *Instance, taskEntries []
 
 		enterTaskData, _ := activeInst.FindOrCreateTaskData(taskEntry.Task)
 
+		enterTaskData.id = enterTaskData.taskID
 		enterResult := taskToEnterBehavior.Enter(enterTaskData)
 
 		if enterResult == model.EnterEval {

--- a/instance/instances.go
+++ b/instance/instances.go
@@ -3,13 +3,12 @@ package instance
 import (
 	"errors"
 	"fmt"
-	"strconv"
-
 	"github.com/project-flogo/core/support"
 	"github.com/project-flogo/core/support/log"
 	"github.com/project-flogo/flow/definition"
 	"github.com/project-flogo/flow/model"
 	flowsupport "github.com/project-flogo/flow/support"
+	"strconv"
 )
 
 type IndependentInstance struct {
@@ -270,9 +269,9 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 	case model.EvalFail:
 		taskInst.SetStatus(model.TaskStatusFailed)
 	case model.EvalRepeat:
-		taskInst.SetStatus(model.TaskStatusReady)
 		taskInst.counter++
 		taskInst.id = taskInst.taskID + "-" + strconv.Itoa(taskInst.counter)
+		taskInst.SetStatus(model.TaskStatusReady)
 		//task needs to iterate or retry
 		inst.scheduleEval(taskInst)
 	}

--- a/model/simple/dowhilebehavior.go
+++ b/model/simple/dowhilebehavior.go
@@ -47,17 +47,6 @@ func (dw *DoWhileTaskBehavior) PostEval(ctx model.TaskContext) (evalResult model
 	_, err = ctx.PostEvalActivity()
 
 	if err != nil {
-		// check if error returned is retriable
-		if errVal, ok := err.(*activity.Error); ok && errVal.Retriable() {
-			// check if task is configured to retry on error
-			retryData, rerr := getRetryData(ctx)
-			if rerr != nil {
-				return model.EvalFail, rerr
-			}
-			if retryData.Count > 0 {
-				return retryPostEval(ctx, retryData), nil
-			}
-		}
 		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
 		ctx.FlowLogger().Errorf("Error post evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
 		ctx.SetStatus(model.TaskStatusFailed)

--- a/model/simple/iteratorbehavior.go
+++ b/model/simple/iteratorbehavior.go
@@ -128,17 +128,6 @@ func (tb *IteratorTaskBehavior) PostEval(ctx model.TaskContext) (evalResult mode
 	_, err = ctx.PostEvalActivity()
 
 	if err != nil {
-		// check if error returned is retriable
-		if errVal, ok := err.(*activity.Error); ok && errVal.Retriable() {
-			// check if task is configured to retry on error
-			retryData, rerr := getRetryData(ctx)
-			if rerr != nil {
-				return model.EvalFail, rerr
-			}
-			if retryData.Count > 0 {
-				return retryPostEval(ctx, retryData), nil
-			}
-		}
 		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
 		ctx.FlowLogger().Errorf("Error post evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
 		ctx.SetStatus(model.TaskStatusFailed)

--- a/model/simple/retry.go
+++ b/model/simple/retry.go
@@ -54,16 +54,16 @@ func retryEval(ctx model.TaskContext, retryData *RetryData) (bool, error) {
 }
 
 // retryPostEval retries current task from PostEval
-func retryPostEval(ctx model.TaskContext, retryData *RetryData) model.EvalResult {
-	ctx.FlowLogger().Debugf("Task[%s] retrying on error. Retries left (%d)...", ctx.Task().ID(), retryData.Count)
-
-	if retryData.Interval > 0 {
-		ctx.FlowLogger().Debugf("Task[%s] sleeping for %d milliseconds...", ctx.Task().ID(), retryData.Interval)
-		time.Sleep(time.Duration(retryData.Interval) * time.Millisecond)
-	}
-
-	// update retry count
-	retryData.Count = retryData.Count - 1
-	ctx.SetWorkingData(retryOnErrorAttr, retryData)
-	return model.EvalRepeat
-}
+//func retryPostEval(ctx model.TaskContext, retryData *RetryData) (bool, error) {
+//	ctx.FlowLogger().Debugf("Task[%s] retrying on error. Retries left (%d)...", ctx.Task().ID(), retryData.Count)
+//
+//	if retryData.Interval > 0 {
+//		ctx.FlowLogger().Debugf("Task[%s] sleeping for %d milliseconds...", ctx.Task().ID(), retryData.Interval)
+//		time.Sleep(time.Duration(retryData.Interval) * time.Millisecond)
+//	}
+//
+//	// update retry count
+//	retryData.Count = retryData.Count - 1
+//	ctx.SetWorkingData(retryOnErrorAttr, retryData)
+//	return evalActivity(ctx)
+//}

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -127,17 +127,17 @@ func (tb *TaskBehavior) PostEval(ctx model.TaskContext) (evalResult model.EvalRe
 	ctx.FlowLogger().Debugf("PostEval Task '%s'", ctx.Task().ID())
 	_, err = ctx.PostEvalActivity()
 	if err != nil {
-		// check if error returned is retriable
-		if errVal, ok := err.(*activity.Error); ok && errVal.Retriable() {
-			// check if task is configured to retry on error
-			retryData, rerr := getRetryData(ctx)
-			if rerr != nil {
-				return model.EvalFail, rerr
-			}
-			if retryData.Count > 0 {
-				return retryPostEval(ctx, retryData), nil
-			}
-		}
+		//// check if error returned is retriable
+		//if errVal, ok := err.(*activity.Error); ok && errVal.Retriable() {
+		//	// check if task is configured to retry on error
+		//	retryData, rerr := getRetryData(ctx)
+		//	if rerr != nil {
+		//		return model.EvalFail, rerr
+		//	}
+		//	if retryData.Count > 0 {
+		//		return retryPostEval(ctx, retryData), nil
+		//	}
+		//}
 		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
 		ctx.FlowLogger().Errorf("Error post evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
 		ctx.SetStatus(model.TaskStatusFailed)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
During the taskInstance creation, the task `Enter()` is called before the task's scheduleEval(). The Enter() method was setting the `SetTaskStatus()` to `Ready` which triggers the `postTaskEvent`. So the notification of `TaskStarted` does not have the `taskInstanceId` because the `taskInstanceId` was being assigned at `scheduleEval()`. 
**What is the new behavior?**
TaskInstanceId = TaskId (done before task `Enter()` is called)
TaskInstanceId = TaskId - 'counter' (for repeating tasks). Done when `execTask` receives `model.EvalRepeat`
