### PR TITLE
Change otherwise link type to exprOtherwise

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -299,8 +299,8 @@ const (
 	// LtError denotes an error link
 	LtError LinkType = 3
 
-	// LtOtherwise denotes an otherwise link
-	LtOtherwise = 4
+	// LtExprOtherwise denotes an expression otherwise link
+	LtExprOtherwise = 4
 )
 
 // LinkOld is the object that describes the definition of

--- a/definition/definition_ser.go
+++ b/definition/definition_ser.go
@@ -368,8 +368,8 @@ func createLink(tasks map[string]*Task, linkRep *LinkRep, id int, ef expression.
 			link.linkType = LtLabel
 		case "error", "3":
 			link.linkType = LtError
-		case "otherwise", "4":
-			link.linkType = LtOtherwise
+		case "exprOtherwise", "4":
+			link.linkType = LtExprOtherwise
 		default:
 			//todo get the flow logger
 			log.RootLogger().Warnf("Unsupported link type '%s', using default link")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe:
```
Today we do have the default, label, expression and error link types, The otherwise makes more confusing for the user to understand. 

The current behavior is: Execute otherwise branch when only there is no other link be executed. 

After discussing with @fm-tibco @vijaynalawade we agreed to change it to exprOtherwise,  it is only for expression type.  Just like the condition with condition false


**Fixes**: #

**What is the current behavior?**

**What is the new behavior?**
