### PR TITLE
Expose GetOutput API to activity context

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -138,7 +138,6 @@ func (ac *ActivityConfig) GetInputSchema(name string) schema.Schema {
 	return nil
 }
 
-//Deprecated
 func (ac *ActivityConfig) GetOutput(name string) interface{} {
 	if ac.outputs != nil {
 		return ac.outputs[name]

--- a/definition/definition_ser.go
+++ b/definition/definition_ser.go
@@ -293,9 +293,9 @@ func createActivityConfig(task *Task, rep *activity.Config, ef expression.Factor
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			activityCfg.outputs = output
+
 		}
+		activityCfg.outputs = output
 	}
 
 	//If outputMapper is null, use default output mapper

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -80,6 +80,19 @@ func (ti *TaskInst) GetInput(name string) interface{} {
 	return nil
 }
 
+// GetOutput implements activity.Context.GetOutput
+func (ti *TaskInst) GetOutput(name string) interface{} {
+	val, found := ti.outputs[name]
+	if found {
+		return val
+	}
+	if len(ti.task.ActivityConfig().Ref()) > 0 {
+		return ti.task.ActivityConfig().GetOutput(name)
+	}
+
+	return nil
+}
+
 // SetOutput implements activity.Context.SetOutput
 func (ti *TaskInst) SetOutput(name string, value interface{}) error {
 
@@ -99,6 +112,13 @@ func (ti *TaskInst) SetOutput(name string, value interface{}) error {
 // GetInputObject implements activity.Context.GetInputObject
 func (ti *TaskInst) GetInputObject(input data.StructValue) error {
 	err := input.FromMap(ti.inputs)
+	return err
+}
+
+// GetOutputObject implements activity.Context.GetOutputObject
+func (ti *TaskInst) GetOutputObject(output data.StructValue) error {
+	//TODO handle output from activity config
+	err := output.FromMap(ti.outputs)
 	return err
 }
 
@@ -579,6 +599,10 @@ func (l *LegacyCtx) GetInputObject(input data.StructValue) error {
 
 func (l *LegacyCtx) SetOutputObject(output data.StructValue) error {
 	return l.task.SetOutputObject(output)
+}
+
+func (l *LegacyCtx) GetOutputObject(output data.StructValue) error {
+	return l.task.GetOutputObject(output)
 }
 
 func (l *LegacyCtx) GetTracingContext() trace.TracingContext {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

Support core PR: https://github.com/project-flogo/core/pull/139
**Fixes**: #

**What is the current behavior?**

Today, We can't get the activity output from context. And it is useful for some activity which requires to get output field value to do some work

FOr example Rest Invoke, we want to expose the ability to let the user define response code/schema
**What is the new behavior?**
Expose GetOutput API to activity context