### PR TITLE
Consistence of dowhile and iterate in settings 

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -182,30 +182,41 @@ func (ac *ActivityConfig) OutputMapper() mapper.Mapper {
 }
 
 type loopCfg struct {
-	doWhile struct {
-		condition expression.Expr
-		delay     int
-	}
-
+	condition    expression.Expr
+	iterate      interface{}
+	delay        int
+	accumulate   bool
 	retryOnError struct {
 		count    int
 		interval int
 	}
 }
 
+func (l *loopCfg) Accumulated() bool {
+	return l.accumulate
+}
+
 func (l *loopCfg) DowhileCondition() expression.Expr {
-	return l.doWhile.condition
+	return l.condition
 }
 
-func (l *loopCfg) EnabledDowhile() bool {
-	return l.doWhile.condition != nil
+func (l *loopCfg) GetIterate() interface{} {
+	return l.iterate
 }
 
-func (l *loopCfg) DoWhileDelay() int {
-	return l.doWhile.delay
+func (l *loopCfg) IterateEnabled() bool {
+	return l.iterate != nil
 }
 
-func (l *loopCfg) EnabledRetryOnError() bool {
+func (l *loopCfg) DowhileEnabled() bool {
+	return l.condition != nil
+}
+
+func (l *loopCfg) Delay() int {
+	return l.delay
+}
+
+func (l *loopCfg) RetryOnErrorEnabled() bool {
 	return l.retryOnError.count > 0
 }
 

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -354,12 +354,12 @@ func (ti *TaskInst) EvalActivity() (done bool, evalErr error) {
 		}
 
 		//skip apply output mapper while enable accumulate for iterator/dowhile
-		if ti.Accumulated() {
+		if ti.Task().LoopConfig().Accumulated() {
 			if err := ti.handleAccumulation(); err != nil {
 				return false, err
 			}
 			//For dowhile condition case, we need add activity output to scope
-			if ti.Task().LoopConfig() != nil && ti.Task().LoopConfig().EnabledDowhile() {
+			if ti.Task().LoopConfig().DowhileEnabled() {
 				err = ti.applyOutputMapper()
 				if err != nil {
 					return done, err
@@ -435,7 +435,7 @@ func (ti *TaskInst) PostEvalActivity() (done bool, evalErr error) {
 			return false, err
 		}
 
-		if ti.Accumulated() {
+		if ti.Task().LoopConfig().Accumulated() {
 			if err := ti.handleAccumulation(); err != nil {
 				return false, err
 			}
@@ -499,16 +499,6 @@ func (ti *TaskInst) getErrorObject(err error) map[string]interface{} {
 		errorObj["activity"] = e.TaskName()
 	}
 	return errorObj
-}
-
-// Accumulated  return whether task enable accumulation in iterator or dowhile
-func (ti *TaskInst) Accumulated() bool {
-	var accumulate bool
-	accumulateOutput, ok := ti.GetSetting("accumulate")
-	if ok {
-		accumulate, _ = coerce.ToBool(accumulateOutput)
-	}
-	return accumulate
 }
 
 func (ti *TaskInst) handleAccumulation() error {

--- a/model/simple/dowhilebehavior.go
+++ b/model/simple/dowhilebehavior.go
@@ -85,9 +85,9 @@ func (dw *DoWhileTaskBehavior) evaluateCondition(ctx model.TaskContext, conditio
 			return model.EvalFail, err
 		}
 		if result.(bool) {
-			delay := ctx.Task().LoopConfig().DoWhileDelay()
+			delay := ctx.Task().LoopConfig().Delay()
 			if delay > 0 {
-				ctx.FlowLogger().Infof("Task[%s] execution delaying for %d milliseconds...", ctx.Task().ID(), delay)
+				ctx.FlowLogger().Infof("Dowhile Task[%s] execution delaying for %d milliseconds...", ctx.Task().ID(), delay)
 				time.Sleep(time.Duration(delay) * time.Millisecond)
 			}
 			ctx.FlowLogger().Infof("Task[%s] repeating as doWhile condition evaluated to true", ctx.Task().ID())

--- a/model/simple/retry.go
+++ b/model/simple/retry.go
@@ -23,7 +23,7 @@ func getRetryData(ctx model.TaskContext) (retryData *RetryData, err error) {
 	if _, ok := ctx.GetWorkingData(retryOnErrorAttr); !ok {
 		// first attempt - build retry data
 		retryData := &RetryData{}
-		if ctx.Task().LoopConfig() != nil && ctx.Task().LoopConfig().EnabledRetryOnError() {
+		if ctx.Task().LoopConfig() != nil && ctx.Task().LoopConfig().RetryOnErrorEnabled() {
 			retryData.Count = ctx.Task().LoopConfig().RetryOnErrorCount()
 			retryData.Interval = ctx.Task().LoopConfig().RetryOnErrorInterval()
 			ctx.SetWorkingData(retryOnErrorAttr, retryData)


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #83 #82 

**What is the current behavior?**
Previous we put dowhile under settings with dowhile node. 
```
 "settings": {
                            "doWhile": {
                                "condition": "=$iteration[index] < 5",
                                "delay": 5
                            },
                            "accumulate": true
         },
```
**What is the new behavior?**
Now put it under settings to keep same with iterator 
```
 "settings": {
                "condition": "=$iteration[index] < 5",
                "delay": 5,
              "accumulate": true
            }
```

Meanwhile we add `delay` field for iterator as well