### PR TITLE
Failed status is not set for Subflow task when subflow returns error

### DIFF
--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -434,6 +434,11 @@ func (inst *IndependentInstance) handleTaskError(taskBehavior model.TaskBehavior
 	if taskInst.traceContext != nil {
 		_ = trace.GetTracer().FinishTrace(taskInst.traceContext, err)
 	}
+	// Set task status to failed for subflow activity
+	if taskInst.status == model.TaskStatusWaiting {
+		taskInst.SetStatus(model.TaskStatusFailed)
+	}
+
 	handled, taskEntries := taskBehavior.Error(taskInst, err)
 
 	containerInst := taskInst.flowInst

--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -427,7 +427,6 @@ func (inst *IndependentInstance) propagateSkip(taskEntries []*model.TaskEntry, a
 	return notify
 }
 
-
 // handleTaskError handles the completion of a task in the Flow Instance
 func (inst *IndependentInstance) handleTaskError(taskBehavior model.TaskBehavior, taskInst *TaskInst, err error) {
 
@@ -435,9 +434,7 @@ func (inst *IndependentInstance) handleTaskError(taskBehavior model.TaskBehavior
 		_ = trace.GetTracer().FinishTrace(taskInst.traceContext, err)
 	}
 	// Set task status to failed for subflow activity
-	if taskInst.status == model.TaskStatusWaiting {
-		taskInst.SetStatus(model.TaskStatusFailed)
-	}
+	taskInst.SetStatus(model.TaskStatusFailed)
 
 	handled, taskEntries := taskBehavior.Error(taskInst, err)
 

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -92,9 +92,10 @@ func (tb *TaskBehavior) Eval(ctx model.TaskContext) (evalResult model.EvalResult
 
 	done, err := evalActivity(ctx)
 	if err != nil {
+
 		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
 		ctx.FlowLogger().Errorf("Error evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
-		ctx.SetStatus(model.TaskStatusFailed)
+		//ctx.SetStatus(model.TaskStatusFailed)
 		return model.EvalFail, err
 	}
 
@@ -161,7 +162,7 @@ func (tb *TaskBehavior) PostEval(ctx model.TaskContext) (evalResult model.EvalRe
 		//}
 		ref := activity.GetRef(ctx.Task().ActivityConfig().Activity)
 		ctx.FlowLogger().Errorf("Error post evaluating activity '%s'[%s] - %s", ctx.Task().ID(), ref, err.Error())
-		ctx.SetStatus(model.TaskStatusFailed)
+		//ctx.SetStatus(model.TaskStatusFailed)
 		return model.EvalFail, err
 	}
 	return model.EvalDone, nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

**What is the new behavior?**
when subflow instance is failed, setting subflow activity status to failed.