### PR TITLE
Able to set resource in exist resource manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/project-flogo/flow
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/project-flogo/core v1.0.0
+	github.com/project-flogo/core v1.0.1-0.20200528154344-f12f8924e332
 	github.com/stretchr/testify v1.4.0
 
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/project-flogo/core v1.0.0 h1:OdJWU89NZcM+YTNWcAQ+yN5/fGN7qCxfTrI0rQ3FrRI=
 github.com/project-flogo/core v1.0.0/go.mod h1:dt3AJeC/QzrgGSoPoZBEdyqR6UAqSMRppz4E47FWmYU=
+github.com/project-flogo/core v1.0.1-0.20200528154344-f12f8924e332/go.mod h1:dt3AJeC/QzrgGSoPoZBEdyqR6UAqSMRppz4E47FWmYU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/support/definition.go
+++ b/support/definition.go
@@ -1,6 +1,7 @@
 package support
 
 import (
+	"fmt"
 	"github.com/project-flogo/core/app/resource"
 	"github.com/project-flogo/flow/definition"
 	"strings"
@@ -41,4 +42,26 @@ func GetDefinition(flowURI string) (*definition.Definition, bool, error) {
 	}
 
 	return nil, false, nil
+}
+
+func SetResource(resources []*resource.Config) error {
+	for _, resConfig := range resources {
+		resType, err := resource.GetTypeFromID(resConfig.ID)
+		if err != nil {
+			return err
+		}
+
+		loader := resource.GetLoader(resType)
+
+		if loader == nil {
+			return fmt.Errorf("resource loader for '%s' not registered", resType)
+		}
+
+		res, err := loader.LoadResource(resConfig)
+		if err != nil {
+			return err
+		}
+		resManager.SetResource(resConfig.ID, res)
+	}
+	return nil
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Not able to set resources into existing resource manager which we want to support call subflow in flow tester

**What is the new behavior?**

We use the default resource manager to manage all flows come from flow debugger to handle subflow etc... In that case we need a way to set the resource to the resource manager. 

