### PR TITLE
Append error data to task inst let it record in state server

### DIFF
--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -476,6 +476,8 @@ func (inst *IndependentInstance) handleTaskError(taskBehavior model.TaskBehavior
 					}
 					inst.handleTaskError(behavior, host, err)
 				}
+			} else {
+				taskInst.appendErrorData(err)
 			}
 
 		} else {


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today there is no error data append to task when activity error happens in the error handler flow which causing no data been save in state server. 

**What is the new behavior?**
Add error data to task when the error happens in error handler flow. 
