### PR TITLE
make sure able to run from tile from error handler

### DIFF
--- a/definition/definition.go
+++ b/definition/definition.go
@@ -405,3 +405,7 @@ func (eh *ErrorHandler) Tasks() []*Task {
 	}
 	return tasks
 }
+
+func (eh *ErrorHandler) GetTask(taskID string) *Task {
+	return eh.tasks[taskID]
+}

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -38,6 +38,11 @@ func initTaskInst(taskInst *TaskInst, flowInst *Instance, task *definition.Task)
 		task = flowInst.flowDef.GetTask(taskInst.taskID)
 	}
 
+	if task == nil {
+		//unable find task from flow, try to get from error handler
+		task = flowInst.flowDef.GetErrorHandler().GetTask(taskInst.taskID)
+	}
+
 	taskInst.flowInst = flowInst
 	taskInst.task = task
 	taskInst.taskID = task.ID()
@@ -372,7 +377,7 @@ func (ti *TaskInst) EvalActivity() (done bool, evalErr error) {
 			return false, err
 		}
 
-		if cfg := ti.Task().LoopConfig(); cfg !=nil && cfg.Accumulate() {
+		if cfg := ti.Task().LoopConfig(); cfg != nil && cfg.Accumulate() {
 			if err := ti.handleAccumulation(); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
For tester today we cannot run tile from the error handler.
**What is the new behavior?**
Fixed the issue to make sure the tester able to run from tile from the error handler flow