### PR TITLE
NPE happens when run from tile has input field which has empty value

### DIFF
--- a/instance/util.go
+++ b/instance/util.go
@@ -91,6 +91,9 @@ func applyInputInterceptor(taskInst *TaskInst) bool {
 						taskInst.logger.Debugf("Overriding Input Attr: %s = %s", name, value)
 					}
 
+					if taskInst.inputs == nil {
+						taskInst.inputs = make(map[string]interface{})
+					}
 					if mdAttr, ok := mdInputs[name]; ok {
 						taskInst.inputs[name], err = coerce.ToType(value, mdAttr.Type())
 						if err != nil {
@@ -132,6 +135,9 @@ func applyOutputInterceptor(taskInst *TaskInst) error {
 					taskInst.logger.Debugf("Overriding Output Attr: %s = %s", name, value)
 				}
 
+				if taskInst.outputs == nil {
+					taskInst.outputs = make(map[string]interface{})
+				}
 				if mdAttr, ok := mdOutput[name]; ok {
 					taskInst.outputs[name], err = coerce.ToType(value, mdAttr.Type())
 					if err != nil {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Given below input for rest invoke and try to run from this tile and panic happens
```
{
  "pathParams": null,
  "queryParams": null,
  "headers": null,
  "content": null
}
```
**What is the new behavior?**

It shouldn't panic as it is valid json 