### PR TITLE
support mapper for retry on error

### DIFF
--- a/model/simple/dowhilebehavior.go
+++ b/model/simple/dowhilebehavior.go
@@ -80,7 +80,7 @@ func (dw *DoWhileTaskBehavior) checkDoWhileCondition(ctx model.TaskContext) (eva
 // Evaluates condition set for do while task
 func (dw *DoWhileTaskBehavior) evaluateCondition(ctx model.TaskContext, condition expression.Expr) (evalResult model.EvalResult, err error) {
 	if t, ok := ctx.(*instance.TaskInst); ok {
-		result, err := condition.Eval(getScope(ctx, t))
+		result, err := condition.Eval(getScope(t))
 		if err != nil {
 			return model.EvalFail, err
 		}
@@ -98,7 +98,7 @@ func (dw *DoWhileTaskBehavior) evaluateCondition(ctx model.TaskContext, conditio
 	return model.EvalDone, nil
 }
 
-func getScope(ctx model.TaskContext, t *instance.TaskInst) data.Scope {
+func getScope(t *instance.TaskInst) data.Scope {
 	if t.GetWorkingDataScope() != nil {
 		return t.GetWorkingDataScope()
 	}

--- a/model/simple/retry.go
+++ b/model/simple/retry.go
@@ -3,6 +3,7 @@ package simple
 import (
 	"errors"
 	"fmt"
+	"github.com/project-flogo/flow/instance"
 	"time"
 
 	"github.com/project-flogo/flow/model"
@@ -30,8 +31,16 @@ func getRetryData(ctx model.TaskContext) (retryData *RetryData, err error) {
 		retryData = &RetryData{}
 
 		retryCfg := ctx.Task().RetryOnErrConfig()
-		retryData.Count = retryCfg.Count()
-		retryData.Interval = retryCfg.Interval()
+		if t, ok := ctx.(*instance.TaskInst); ok {
+			retryData.Count, err = retryCfg.Count(getScope(t))
+			if err != nil {
+				return nil, err
+			}
+			retryData.Interval, err = retryCfg.Interval(getScope(t))
+			if err != nil {
+				return nil, err
+			}
+		}
 		ctx.SetWorkingData(retryOnErrorAttr, retryData)
 	} else {
 		retryData, ok = rd.(*RetryData)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today the retry on error field count and interval just supports App property.  It would be super helpful to support mapping
**What is the new behavior?**
Now user able to give mapping ref to count and interval. such as `"count":"$flow.body.count"`