### PR TITLE
Add all return data into host outputs for subflow in case mixed data

### DIFF
--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -368,11 +368,7 @@ func (inst *IndependentInstance) handleTaskDone(taskBehavior model.TaskBehavior,
 			host, ok := containerInst.host.(*TaskInst)
 
 			if ok {
-				//if the flow failed, set the error
-				for name, value := range containerInst.returnData {
-					//todo review how we should handle an error encountered here
-					_ = host.SetOutput(name, value)
-				}
+				host.SetOutputs(containerInst.returnData)
 				//Sub flow done
 				containerInst.master.GetChanges().SubflowDone(containerInst)
 				inst.scheduleEval(host)

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -120,6 +120,17 @@ func (ti *TaskInst) SetOutput(name string, value interface{}) error {
 	return nil
 }
 
+func (ti *TaskInst) SetOutputs(outputs map[string]interface{}) error {
+
+	if ti.logger.DebugEnabled() {
+		ti.logger.Debugf("Task[%s] - Set Outputs: %v", ti.taskID, outputs)
+	}
+
+	ti.outputs = outputs
+
+	return nil
+}
+
 // GetInputObject implements activity.Context.GetInputObject
 func (ti *TaskInst) GetInputObject(input data.StructValue) error {
 	err := input.FromMap(ti.inputs)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

Old subflow returned data still in output as we just add key/value to the existing map. 
**What is the new behavior?**
For each sub-flow output, we should clean up the last output and use only itself.
