### PR TITLE
Set task name as operation name in tracing config

### DIFF
--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -571,7 +571,7 @@ func (ti *TaskInst) copyOutputs() map[string]interface{} {
 
 func (ti *TaskInst) SpanConfig() trace.Config {
 	config := trace.Config{}
-	config.Operation = ti.flowInst.Name()
+	config.Operation = ti.task.Name()
 	config.Tags = make(map[string]interface{})
 	config.Tags["flow_id"] = ti.flowInst.ID()
 	config.Tags["flow_name"] = ti.flowInst.Name()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
In tracing tools like Jaeger, task span name is set to flow name which is incorrect.
**What is the new behavior?**
Now, span name is set to activity/task name