### PR TITLE
make propagate skip property configurable via env

### DIFF
--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -9,11 +9,12 @@ import (
 	"github.com/project-flogo/flow/definition"
 	"github.com/project-flogo/flow/instance"
 	"github.com/project-flogo/flow/model"
+	"github.com/project-flogo/flow/support"
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-const PropagateSkip = true
+var propagateSkip = support.GetPropagateSkip()
 
 // TaskBehavior implements model.TaskBehavior
 type TaskBehavior struct {
@@ -312,14 +313,14 @@ func (tb *TaskBehavior) Skip(ctx model.TaskContext) (notifyFlow bool, taskEntrie
 			taskEntries = append(taskEntries, taskEntry)
 		}
 
-		return false, taskEntries, PropagateSkip
+		return false, taskEntries, propagateSkip
 	}
 
 	if logger.DebugEnabled() {
 		logger.Debugf("Notifying flow that end task '%s' is skipped", ctx.Task().ID())
 	}
 
-	return true, nil, PropagateSkip
+	return true, nil, propagateSkip
 }
 
 // Error implements model.TaskBehavior.Error

--- a/support/env.go
+++ b/support/env.go
@@ -1,15 +1,19 @@
 package support
 
 import (
-	"github.com/project-flogo/core/engine"
 	"os"
+
+	"github.com/project-flogo/core/data/coerce"
+	"github.com/project-flogo/core/engine"
 )
 
 const (
-	UserName   = "FLOGO_APP_USERNAME"
-	HostName   = "FLOGO_HOST_NAME"
-	AppName    = "FLOGO_APP_NAME"
-	AppVersion = "FLOGO_APP_VERSION"
+	UserName                  = "FLOGO_APP_USERNAME"
+	HostName                  = "FLOGO_HOST_NAME"
+	AppName                   = "FLOGO_APP_NAME"
+	AppVersion                = "FLOGO_APP_VERSION"
+	PropagateSkip             = "FLOGO_TASK_PROPAGATE_SKIP"
+	PropagateSkipDefault bool = true
 )
 
 var username, hostName, appName, appVersion string
@@ -57,4 +61,16 @@ func GetAppVerison() string {
 		return engine.GetAppVersion()
 	}
 	return appVersion
+}
+
+func GetPropagateSkip() bool {
+	v, ok := os.LookupEnv(PropagateSkip)
+	if !ok {
+		return PropagateSkipDefault
+	}
+	propagateSkip, err := coerce.ToBool(v)
+	if err != nil {
+		return PropagateSkipDefault
+	}
+	return propagateSkip
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
Make propagateSkip variable for taskbehavior configurable via env

**What is the current behavior?**
With current code, we cannot configure it via env

**What is the new behavior?**
The propagateSkip is now configurable via env var `FLOGO_TASK_PROPAGATE_SKIP`