### PR TITLE
add env flag to change task link priority

### DIFF
--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -388,14 +388,14 @@ func getEnterCode(linkInst model.LinkInstance) int {
 		Task with maximum enter code will execute first (except with enter code Skip i.e. 4)
 
 		Enter code (default)
-		0 -> Default or dependence link type
+		0 -> Default or dependency link type
 		1 -> Expression branches
 	    2 -> Otherwise branch
 		3 -> Label or success branch
 		4 -> Skip
 
 		New Enter Code
-		0 -> Default or dependence link type
+		0 -> Default or dependency link type
 		1 -> Label or success branch
 		2 -> Otherwise branch
 		3 -> Expression branches

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -227,13 +227,13 @@ func (tb *TaskBehavior) Done(ctx model.TaskContext) (notifyFlow bool, taskEntrie
 
 			if linkInst.Link().Type() == definition.LtDependency {
 				linkInst.SetStatus(model.LinkStatusTrue)
-				taskEntry.EnterCode = 0
+				taskEntry.EnterCode = getEnterCode(linkInst)
 				continue
 			}
 
 			if linkInst.Link().Type() == definition.LtLabel {
 				linkInst.SetStatus(model.LinkStatusTrue)
-				taskEntry.EnterCode = 3
+				taskEntry.EnterCode = getEnterCode(linkInst)
 				continue
 			}
 
@@ -254,7 +254,7 @@ func (tb *TaskBehavior) Done(ctx model.TaskContext) (notifyFlow bool, taskEntrie
 				if follow {
 					exprLinkFollowed = true
 					linkInst.SetStatus(model.LinkStatusTrue)
-					taskEntry.EnterCode = 1
+					taskEntry.EnterCode = getEnterCode(linkInst)
 					if logger.DebugEnabled() {
 						logger.Debugf("Task '%s': Following Expression Link to task '%s'", ctx.Task().ID(), linkInst.Link().ToTask().ID())
 					}
@@ -266,7 +266,7 @@ func (tb *TaskBehavior) Done(ctx model.TaskContext) (notifyFlow bool, taskEntrie
 		if exprOtherwiseLinkInst != nil && hasExprLink && !exprLinkFollowed {
 			exprOtherwiseLinkInst.SetStatus(model.LinkStatusTrue)
 			//TODO For now keep previous order, otherwise running first.
-			exprOtherwiseTaskEntry.EnterCode = 2
+			exprOtherwiseTaskEntry.EnterCode = getEnterCode(exprOtherwiseLinkInst)
 			if logger.DebugEnabled() {
 				logger.Debugf("Task '%s': Following Otherwise Link to task '%s'", ctx.Task().ID(), exprOtherwiseLinkInst.Link().ToTask().ID())
 			}
@@ -380,6 +380,45 @@ func linkStatus(inst model.LinkInstance) string {
 	}
 
 	return "unknown"
+}
+
+func getEnterCode(linkInst model.LinkInstance) int {
+	/**
+		Execution order will depend on the enter code
+		Task with maximum enter code will execute first (except with enter code Skip i.e. 4)
+
+		Enter code (default)
+		0 -> Default or dependence link type
+		1 -> Expression branches
+	    2 -> Otherwise branch
+		3 -> Label or success branch
+		4 -> Skip
+
+		New Enter Code
+		0 -> Default or dependence link type
+		1 -> Label or success branch
+		2 -> Otherwise branch
+		3 -> Expression branches
+		4 -> Skip
+	*/
+
+	switch linkInst.Link().Type() {
+	case definition.LtDependency:
+		return 0
+	case definition.LtExprOtherwise:
+		return 2
+	case definition.LtLabel:
+		if support.GetPrioritizeExprTask() {
+			return 1
+		}
+		return 3
+	case definition.LtExpression:
+		if support.GetPrioritizeExprTask() {
+			return 3
+		}
+		return 1
+	}
+	return 4
 }
 
 //SortTaskEntries Sort by EnterCode, keeping original order or equal elements.

--- a/model/simple/taskbehavior.go
+++ b/model/simple/taskbehavior.go
@@ -9,11 +9,12 @@ import (
 	"github.com/project-flogo/flow/definition"
 	"github.com/project-flogo/flow/instance"
 	"github.com/project-flogo/flow/model"
+	"github.com/project-flogo/flow/support"
 )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-const PropagateSkip = true
+var propagateSkip = support.GetPropagateSkip()
 
 // TaskBehavior implements model.TaskBehavior
 type TaskBehavior struct {
@@ -312,14 +313,14 @@ func (tb *TaskBehavior) Skip(ctx model.TaskContext) (notifyFlow bool, taskEntrie
 			taskEntries = append(taskEntries, taskEntry)
 		}
 
-		return false, taskEntries, PropagateSkip
+		return false, taskEntries, propagateSkip
 	}
 
 	if logger.DebugEnabled() {
 		logger.Debugf("Notifying flow that end task '%s' is skipped", ctx.Task().ID())
 	}
 
-	return true, nil, PropagateSkip
+	return true, nil, propagateSkip
 }
 
 // Error implements model.TaskBehavior.Error

--- a/support/env.go
+++ b/support/env.go
@@ -1,15 +1,19 @@
 package support
 
 import (
-	"github.com/project-flogo/core/engine"
 	"os"
+
+	"github.com/project-flogo/core/data/coerce"
+	"github.com/project-flogo/core/engine"
 )
 
 const (
-	UserName   = "FLOGO_APP_USERNAME"
-	HostName   = "FLOGO_HOST_NAME"
-	AppName    = "FLOGO_APP_NAME"
-	AppVersion = "FLOGO_APP_VERSION"
+	UserName                  = "FLOGO_APP_USERNAME"
+	HostName                  = "FLOGO_HOST_NAME"
+	AppName                   = "FLOGO_APP_NAME"
+	AppVersion                = "FLOGO_APP_VERSION"
+	PropagateSkip             = "FLOGO_TASK_PROPAGATE_SKIP"
+	PropagateSkipDefault bool = true
 )
 
 var username, hostName, appName, appVersion string
@@ -57,4 +61,16 @@ func GetAppVerison() string {
 		return engine.GetAppVersion()
 	}
 	return appVersion
+}
+
+func GetPropagateSkip() bool {
+	v, ok := os.LookupEnv(PropagateSkip)
+	if !ok {
+		return PropagateSkipDefault
+	}
+	propagateSkip, err := coerce.ToBool(v)
+	if err != nil {
+		return PropagateSkipDefault
+	}
+	return propagateSkip
 }

--- a/support/env.go
+++ b/support/env.go
@@ -8,12 +8,16 @@ import (
 )
 
 const (
-	UserName                  = "FLOGO_APP_USERNAME"
-	HostName                  = "FLOGO_HOST_NAME"
-	AppName                   = "FLOGO_APP_NAME"
-	AppVersion                = "FLOGO_APP_VERSION"
+	UserName   = "FLOGO_APP_USERNAME"
+	HostName   = "FLOGO_HOST_NAME"
+	AppName    = "FLOGO_APP_NAME"
+	AppVersion = "FLOGO_APP_VERSION"
+
 	PropagateSkip             = "FLOGO_TASK_PROPAGATE_SKIP"
 	PropagateSkipDefault bool = true
+
+	PrioritizeExprLink             = "FLOGO_TASK_PRIORITIZE_EXPR_LINK"
+	PrioritizeExprLinkDefault bool = false
 )
 
 var username, hostName, appName, appVersion string
@@ -73,4 +77,16 @@ func GetPropagateSkip() bool {
 		return PropagateSkipDefault
 	}
 	return propagateSkip
+}
+
+func GetPrioritizeExprTask() bool {
+	v, ok := os.LookupEnv(PrioritizeExprLink)
+	if !ok {
+		return PrioritizeExprLinkDefault
+	}
+	prioritizeExpression, err := coerce.ToBool(v)
+	if err != nil {
+		return PrioritizeExprLinkDefault
+	}
+	return prioritizeExpression
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently the order of execution for link types is this:
1. Label or success branch
2. Otherwise branch
3. Expression branches
4. Default or dependency link type

**What is the new behavior?**
When we set the env flag `FLOGO_TASK_PRIORITIZE_EXPR_LINK` to `true` the order will change to:
1. Expression branches
2. Otherwise branch
3. Label or success branch
4. Default or dependence link type

The default value for this flag is set to `false`. This will ensure the old behavior is unchanged.