### PR TITLE
Supporting detached mode for subflow invocation

### DIFF
--- a/action.go
+++ b/action.go
@@ -180,7 +180,7 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 	var flowURI string
 	var preserveInstanceId, originalInstanceId string
 	var initStepId int
-	var rerun bool
+	var rerun, detachExecution bool
 	runOptions, exists := inputs["_run_options"]
 
 	var execOptions *instance.ExecOptions
@@ -197,6 +197,7 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 			initStepId = ro.InitStepId
 			rerun = ro.Rerun
 			originalInstanceId = ro.OriginalInstanceId
+			detachExecution = ro.DetachExecution
 		}
 	}
 
@@ -297,6 +298,7 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 		logger.Debugf("Applying Exec Options to instance: %s", inst.ID())
 		instance.ApplyExecOptions(inst, execOptions)
 	}
+
 	//Update flow starting time
 	inst.UpdateStartTime()
 	if stateRecorder != nil {
@@ -305,12 +307,16 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 		stateRecorder.RecordStart(flowState)
 	}
 
+	eventID := trigger.GetHandlerEventIdFromContext(ctx)
+	if eventID != "" {
+		// Add eventId to the instance
+		_ = inst.SetValue(instance.EventIdAttr, eventID)
+	}
 	if trace.Enabled() {
 		tc, err := trace.GetTracer().StartTrace(inst.SpanConfig(), trace.ExtractTracingContext(ctx))
 		if err != nil {
 			return err
 		}
-		eventID := trigger.GetHandlerEventIdFromContext(ctx)
 		if eventID != "" {
 			tc.SetTag("flogo_event_id", eventID)
 		}
@@ -347,8 +353,12 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 	}
 
 	go func() {
-
-		defer handler.Done()
+		if detachExecution {
+			// In detached mode, no reply expected. So, notifying handler.
+			handler.Done()
+		} else {
+			defer handler.Done()
+		}
 
 		if retID {
 

--- a/activity/subflow/descriptor.json
+++ b/activity/subflow/descriptor.json
@@ -2,7 +2,7 @@
   "name": "flogo-subflow",
   "type": "flogo:activity",
   "ref": "github.com/project-flogo/flow/activity/subflow",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "title": "Start a SubFlow",
   "description": "Activity to start a sub-flow in an existing flow",
   "homepage": "https://github.com/project-flogo/flow/tree/master/activity/subflow",
@@ -11,6 +11,12 @@
       "name": "flowURI",
       "type": "string",
       "required": true
+    },
+    {
+      "name": "detached",
+      "type": "boolean",
+      "required": false,
+      "value": false
     }
   ]
 }

--- a/instance/exec.go
+++ b/instance/exec.go
@@ -21,6 +21,7 @@ type RunOptions struct {
 	ExecOptions         *ExecOptions
 	Rerun               bool
 	OriginalInstanceId  string
+	DetachExecution     bool
 }
 
 // ExecOptions are optional Patch & Interceptor to be used during instance execution


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently subflow invocation is inlined with main flow. So, main flow waits for subflow to complete. In fire and forget use cases, users would like to simply invoke subflows asynchronously without subflow completion. This is not possible today.
**What is the new behavior?**
With this change, users can enable fire and forget use cases