### PR TITLE
Flogo-17605: Fix schema validation for legacy flow definitions

### DIFF
--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -1301,7 +1301,7 @@ func (inst *IndependentInstance) validateFlowInput(md *metadata.IOMetadata, inpu
 
 	s, err := schema.New(schemaDef)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	if s != nil {

--- a/instance/taskevents.go
+++ b/instance/taskevents.go
@@ -104,9 +104,6 @@ func postTaskEvent(taskInstance *TaskInst) {
 		te.flowName = taskInstance.flowInst.Name()
 		te.flowId = taskInstance.flowInst.ID()
 		te.typeId = taskInstance.Task().TypeID()
-		if te.typeId == "" {
-			te.typeId = taskInstance.Task().ActivityConfig().Type
-		}
 		te.id = taskInstance.id
 
 		if taskInstance.HasActivity() {

--- a/instance/taskevents.go
+++ b/instance/taskevents.go
@@ -104,6 +104,9 @@ func postTaskEvent(taskInstance *TaskInst) {
 		te.flowName = taskInstance.flowInst.Name()
 		te.flowId = taskInstance.flowInst.ID()
 		te.typeId = taskInstance.Task().TypeID()
+		if te.typeId == "" {
+			te.typeId = taskInstance.Task().ActivityConfig().Type
+		}
 		te.id = taskInstance.id
 
 		if taskInstance.HasActivity() {

--- a/support/resource.go
+++ b/support/resource.go
@@ -18,7 +18,9 @@ type FlowLoader struct {
 func (*FlowLoader) LoadResource(config *resource.Config) (*resource.Resource, error) {
 	var flowDefBytes []byte
 
-	flowDefBytes = config.Data
+	// flowDefBytes = config.Data  // this is previouse logic before normalization, kept for reference
+
+	flowDefBytes = normalizeLegacySchemaValues(config.Data) // normalize wrong schema values to ensure backward compatibility with older flow definitions
 
 	var defRep *definition.DefinitionRep
 	err := json.Unmarshal(flowDefBytes, &defRep)
@@ -32,4 +34,180 @@ func (*FlowLoader) LoadResource(config *resource.Config) (*resource.Resource, er
 	}
 
 	return resource.New(ResTypeFlow, flow), nil
+}
+
+func normalizeLegacySchemaValues(flowDefBytes []byte) []byte {
+	var flowRep interface{}
+	if err := json.Unmarshal(flowDefBytes, &flowRep); err != nil {
+		return flowDefBytes
+	}
+
+	normalizeSchemaValueInTree(flowRep)
+
+	normalized, err := json.Marshal(flowRep)
+	if err != nil {
+		return flowDefBytes
+	}
+
+	return normalized
+}
+
+func normalizeSchemaValueInTree(node interface{}) {
+	switch n := node.(type) {
+	case map[string]interface{}:
+		if schemaRep, ok := n["schema"].(map[string]interface{}); ok {
+			normalizeSingleSchemaValue(schemaRep, n["type"])
+		}
+
+		for _, child := range n {
+			normalizeSchemaValueInTree(child)
+		}
+	case []interface{}:
+		for _, child := range n {
+			normalizeSchemaValueInTree(child)
+		}
+	}
+}
+
+func normalizeSingleSchemaValue(schemaRep map[string]interface{}, ownerType interface{}) {
+	typeName, ok := ownerType.(string)
+	if !ok || typeName != "object" {
+		return
+	}
+
+	schemaType, ok := schemaRep["type"].(string)
+	if !ok || schemaType != "json" {
+		return
+	}
+
+	schemaValue, ok := schemaRep["value"].(string)
+	if !ok || schemaValue == "" {
+		return
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(schemaValue), &obj); err != nil {
+		return
+	}
+
+	if len(obj) == 0 || hasJSONSchemaKeywords(obj) || !looksLikePropertyMap(obj) {
+		return
+	}
+
+	obj = normalizeLegacyRefs(obj)
+
+	wrapped := map[string]interface{}{
+		"type":       "object",
+		"properties": obj,
+	}
+
+	normalized, err := json.Marshal(wrapped)
+	if err != nil {
+		return
+	}
+
+	schemaRep["value"] = string(normalized)
+}
+
+func looksLikePropertyMap(obj map[string]interface{}) bool {
+	for _, v := range obj {
+		child, ok := v.(map[string]interface{})
+		if !ok {
+			return false
+		}
+
+		if ref, ok := child["$ref"].(string); ok && ref != "" {
+			continue
+		}
+
+		t, ok := child["type"].(string)
+		if !ok || t == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func hasJSONSchemaKeywords(obj map[string]interface{}) bool {
+	// Definite schema-only keywords.
+	for _, key := range []string{"$schema", "$id", "$ref", "definitions", "items", "oneOf", "anyOf", "allOf", "not", "enum", "additionalProperties"} {
+		if _, ok := obj[key]; ok {
+			return true
+		}
+	}
+
+	// 'type' keyword is valid only when string or array of strings.
+	if v, ok := obj["type"]; ok {
+		if _, isString := v.(string); isString || isStringArray(v) {
+			return true
+		}
+	}
+
+	// 'required' keyword is valid only when array of strings.
+	if v, ok := obj["required"]; ok {
+		if isStringArray(v) {
+			return true
+		}
+	}
+
+	// If there is a top-level 'properties' and a valid top-level 'type', treat as schema.
+	if _, hasProperties := obj["properties"]; hasProperties {
+		if t, ok := obj["type"]; ok {
+			if _, isString := t.(string); isString || isStringArray(t) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isStringArray(v interface{}) bool {
+	a, ok := v.([]interface{})
+	if !ok || len(a) == 0 {
+		return false
+	}
+
+	for _, item := range a {
+		if _, ok := item.(string); !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func normalizeLegacyRefs(properties map[string]interface{}) map[string]interface{} {
+	normalized := make(map[string]interface{}, len(properties))
+
+	for k, v := range properties {
+		child, ok := v.(map[string]interface{})
+		if !ok {
+			normalized[k] = v
+			continue
+		}
+
+		if ref, ok := child["$ref"].(string); ok && ref != "" {
+			normalized[k] = map[string]interface{}{"type": "object"}
+			continue
+		}
+
+		// Legacy schemas may contain array items with $ref but no definitions.
+		if t, ok := child["type"].(string); ok && t == "array" {
+			if items, ok := child["items"].(map[string]interface{}); ok {
+				if ref, ok := items["$ref"].(string); ok && ref != "" {
+					normalized[k] = map[string]interface{}{
+						"type":  "array",
+						"items": map[string]interface{}{"type": "object"},
+					}
+					continue
+				}
+			}
+		}
+
+		normalized[k] = child
+	}
+
+	return normalized
 }

--- a/support/resource_test.go
+++ b/support/resource_test.go
@@ -1,0 +1,391 @@
+package support
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── isStringArray ────────────────────────────────────────────────────────────
+
+func TestIsStringArray(t *testing.T) {
+	assert.False(t, isStringArray(nil))
+	assert.False(t, isStringArray("string"))
+	assert.False(t, isStringArray(42))
+	assert.False(t, isStringArray([]interface{}{}), "empty slice should be false")
+	assert.True(t, isStringArray([]interface{}{"a", "b"}))
+	assert.False(t, isStringArray([]interface{}{"a", 1}), "mixed types should be false")
+	assert.False(t, isStringArray([]interface{}{nil}), "nil element should be false")
+}
+
+// ── hasJSONSchemaKeywords ────────────────────────────────────────────────────
+
+func TestHasJSONSchemaKeywords_DefiniteKeywords(t *testing.T) {
+	definite := []string{
+		"$schema", "$id", "$ref", "definitions", "items",
+		"oneOf", "anyOf", "allOf", "not", "enum", "additionalProperties",
+	}
+	for _, key := range definite {
+		assert.True(t, hasJSONSchemaKeywords(map[string]interface{}{key: "v"}), "key %q should match", key)
+	}
+}
+
+func TestHasJSONSchemaKeywords_TypeKeyword(t *testing.T) {
+	// string value → schema keyword
+	assert.True(t, hasJSONSchemaKeywords(map[string]interface{}{"type": "object"}))
+	// string-array value → schema keyword
+	assert.True(t, hasJSONSchemaKeywords(map[string]interface{}{"type": []interface{}{"string", "null"}}))
+	// non-string, non-array value → not a schema keyword
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{"type": 42}))
+	// bool value → not treated as schema keyword
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{"type": true}))
+}
+
+func TestHasJSONSchemaKeywords_RequiredKeyword(t *testing.T) {
+	// string-array value → schema keyword
+	assert.True(t, hasJSONSchemaKeywords(map[string]interface{}{"required": []interface{}{"field1", "field2"}}))
+	// non-string-array → not a schema keyword
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{"required": []interface{}{1, 2}}))
+	// empty slice → not a schema keyword (isStringArray returns false for empty)
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{"required": []interface{}{}}))
+}
+
+func TestHasJSONSchemaKeywords_PropertiesWithType(t *testing.T) {
+	// properties + string type → schema keyword
+	assert.True(t, hasJSONSchemaKeywords(map[string]interface{}{
+		"properties": map[string]interface{}{},
+		"type":       "object",
+	}))
+	// properties alone, no valid type → not detected as schema
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{
+		"properties": map[string]interface{}{},
+	}))
+	// properties with non-string type → not detected
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{
+		"properties": map[string]interface{}{},
+		"type":       42,
+	}))
+}
+
+func TestHasJSONSchemaKeywords_EmptyMap(t *testing.T) {
+	assert.False(t, hasJSONSchemaKeywords(map[string]interface{}{}))
+}
+
+// ── looksLikePropertyMap ─────────────────────────────────────────────────────
+
+func TestLooksLikePropertyMap(t *testing.T) {
+	// empty map – no entries to fail, returns true
+	assert.True(t, looksLikePropertyMap(map[string]interface{}{}))
+
+	// all values are objects with a non-empty "type"
+	assert.True(t, looksLikePropertyMap(map[string]interface{}{
+		"name": map[string]interface{}{"type": "string"},
+		"age":  map[string]interface{}{"type": "integer"},
+	}))
+
+	// value with a non-empty $ref is acceptable
+	assert.True(t, looksLikePropertyMap(map[string]interface{}{
+		"nested": map[string]interface{}{"$ref": "#/definitions/Foo"},
+	}))
+
+	// value is a primitive, not a map → false
+	assert.False(t, looksLikePropertyMap(map[string]interface{}{
+		"name": "John",
+	}))
+
+	// value is a map but has no "type" and no "$ref" → false
+	assert.False(t, looksLikePropertyMap(map[string]interface{}{
+		"name": map[string]interface{}{"description": "a name"},
+	}))
+
+	// value is a map with empty "type" → false
+	assert.False(t, looksLikePropertyMap(map[string]interface{}{
+		"name": map[string]interface{}{"type": ""},
+	}))
+
+	// $ref present but empty string → falls through to type check, which is missing → false
+	assert.False(t, looksLikePropertyMap(map[string]interface{}{
+		"name": map[string]interface{}{"$ref": ""},
+	}))
+}
+
+// ── normalizeLegacyRefs ──────────────────────────────────────────────────────
+
+func TestNormalizeLegacyRefs_RefReplacedWithObject(t *testing.T) {
+	input := map[string]interface{}{
+		"foo": map[string]interface{}{"$ref": "#/definitions/Foo"},
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, map[string]interface{}{"type": "object"}, result["foo"])
+}
+
+func TestNormalizeLegacyRefs_ArrayItemsRefReplaced(t *testing.T) {
+	input := map[string]interface{}{
+		"tags": map[string]interface{}{
+			"type":  "array",
+			"items": map[string]interface{}{"$ref": "#/definitions/Tag"},
+		},
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, map[string]interface{}{
+		"type":  "array",
+		"items": map[string]interface{}{"type": "object"},
+	}, result["tags"])
+}
+
+func TestNormalizeLegacyRefs_PlainTypeKept(t *testing.T) {
+	input := map[string]interface{}{
+		"name": map[string]interface{}{"type": "string"},
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, map[string]interface{}{"type": "string"}, result["name"])
+}
+
+func TestNormalizeLegacyRefs_NonMapValueKept(t *testing.T) {
+	input := map[string]interface{}{
+		"count": 42,
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, 42, result["count"])
+}
+
+func TestNormalizeLegacyRefs_ArrayWithoutItemsRefKept(t *testing.T) {
+	input := map[string]interface{}{
+		"tags": map[string]interface{}{
+			"type":  "array",
+			"items": map[string]interface{}{"type": "string"},
+		},
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, map[string]interface{}{
+		"type":  "array",
+		"items": map[string]interface{}{"type": "string"},
+	}, result["tags"])
+}
+
+func TestNormalizeLegacyRefs_EmptyRefIgnored(t *testing.T) {
+	// $ref present but empty → not treated as a ref, kept as-is
+	input := map[string]interface{}{
+		"foo": map[string]interface{}{"$ref": "", "type": "string"},
+	}
+	result := normalizeLegacyRefs(input)
+	assert.Equal(t, map[string]interface{}{"$ref": "", "type": "string"}, result["foo"])
+}
+
+// ── normalizeSingleSchemaValue ───────────────────────────────────────────────
+
+func TestNormalizeSingleSchemaValue_OwnerTypeNotString(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "json", "value": `{"name":{"type":"string"}}`}
+	normalizeSingleSchemaValue(schemaRep, 123)
+	assert.Equal(t, `{"name":{"type":"string"}}`, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_OwnerTypeNotObject(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "json", "value": `{"name":{"type":"string"}}`}
+	normalizeSingleSchemaValue(schemaRep, "string")
+	assert.Equal(t, `{"name":{"type":"string"}}`, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_SchemaTypeNotJSON(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "xml", "value": `{"name":{"type":"string"}}`}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	assert.Equal(t, `{"name":{"type":"string"}}`, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_EmptyValue(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "json", "value": ""}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	assert.Equal(t, "", schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_InvalidJSONValue(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "json", "value": "not-valid-json"}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	assert.Equal(t, "not-valid-json", schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_EmptyObject(t *testing.T) {
+	schemaRep := map[string]interface{}{"type": "json", "value": `{}`}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	assert.Equal(t, `{}`, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_AlreadyHasSchemaKeywords(t *testing.T) {
+	original := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	schemaRep := map[string]interface{}{"type": "json", "value": original}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	// should not be modified – already a valid JSON schema
+	assert.Equal(t, original, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_DoesNotLookLikePropertyMap(t *testing.T) {
+	// top-level values are primitives, not property objects
+	original := `{"name":"John","age":30}`
+	schemaRep := map[string]interface{}{"type": "json", "value": original}
+	normalizeSingleSchemaValue(schemaRep, "object")
+	assert.Equal(t, original, schemaRep["value"])
+}
+
+func TestNormalizeSingleSchemaValue_LegacyPropertyMapWrapped(t *testing.T) {
+	schemaRep := map[string]interface{}{
+		"type":  "json",
+		"value": `{"name":{"type":"string"},"age":{"type":"integer"}}`,
+	}
+	normalizeSingleSchemaValue(schemaRep, "object")
+
+	normalized, ok := schemaRep["value"].(string)
+	require.True(t, ok)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(normalized), &result))
+	assert.Equal(t, "object", result["type"])
+
+	props, ok := result["properties"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, props, "name")
+	assert.Contains(t, props, "age")
+}
+
+func TestNormalizeSingleSchemaValue_LegacyRefInPropertyMap(t *testing.T) {
+	// A legacy property map with a $ref; normalizeLegacyRefs should replace it with {"type":"object"}
+	schemaRep := map[string]interface{}{
+		"type":  "json",
+		"value": `{"child":{"$ref":"#/definitions/Child"}}`,
+	}
+	normalizeSingleSchemaValue(schemaRep, "object")
+
+	normalized, ok := schemaRep["value"].(string)
+	require.True(t, ok)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(normalized), &result))
+	assert.Equal(t, "object", result["type"])
+
+	props, ok := result["properties"].(map[string]interface{})
+	require.True(t, ok)
+	childProp, ok := props["child"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "object", childProp["type"])
+	assert.NotContains(t, childProp, "$ref")
+}
+
+// ── normalizeLegacySchemaValues (integration) ────────────────────────────────
+
+func TestNormalizeLegacySchemaValues_InvalidJSON(t *testing.T) {
+	input := []byte("not-valid-json")
+	assert.Equal(t, input, normalizeLegacySchemaValues(input))
+}
+
+func TestNormalizeLegacySchemaValues_NoSchemaFields(t *testing.T) {
+	input := []byte(`{"name":"test","version":1}`)
+	result := normalizeLegacySchemaValues(input)
+	assert.JSONEq(t, `{"name":"test","version":1}`, string(result))
+}
+
+func TestNormalizeLegacySchemaValues_LegacySchemaInNestedActivity(t *testing.T) {
+	legacyFlow := `{
+		"activities": [{
+			"type": "object",
+			"schema": {
+				"type": "json",
+				"value": "{\"name\":{\"type\":\"string\"},\"count\":{\"type\":\"integer\"}}"
+			}
+		}]
+	}`
+
+	result := normalizeLegacySchemaValues([]byte(legacyFlow))
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	activity := parsed["activities"].([]interface{})[0].(map[string]interface{})
+	schema := activity["schema"].(map[string]interface{})
+	normalizedValue := schema["value"].(string)
+
+	var schemaObj map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(normalizedValue), &schemaObj))
+
+	assert.Equal(t, "object", schemaObj["type"])
+	props, ok := schemaObj["properties"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, props, "name")
+	assert.Contains(t, props, "count")
+}
+
+func TestNormalizeLegacySchemaValues_AlreadyNormalizedSchemaUnchanged(t *testing.T) {
+	flow := `{
+		"type": "object",
+		"schema": {
+			"type": "json",
+			"value": "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}"
+		}
+	}`
+
+	result := normalizeLegacySchemaValues([]byte(flow))
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	schema := parsed["schema"].(map[string]interface{})
+	normalizedValue := schema["value"].(string)
+
+	// The schema already had keywords, so normalizeSingleSchemaValue must have been a no-op.
+	assert.JSONEq(t, `{"type":"object","properties":{"name":{"type":"string"}}}`, normalizedValue)
+}
+
+func TestNormalizeLegacySchemaValues_NonObjectOwnerTypeSkipped(t *testing.T) {
+	// schema present but owner type is "string", not "object" → no normalization
+	flow := `{
+		"type": "string",
+		"schema": {
+			"type": "json",
+			"value": "{\"name\":{\"type\":\"string\"}}"
+		}
+	}`
+
+	result := normalizeLegacySchemaValues([]byte(flow))
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+	schema := parsed["schema"].(map[string]interface{})
+	assert.Equal(t, `{"name":{"type":"string"}}`, schema["value"])
+}
+
+func TestNormalizeLegacySchemaValues_ArraysTraversed(t *testing.T) {
+	// Verify that arrays at multiple levels are walked correctly.
+	flow := `{
+		"tasks": [
+			{
+				"type": "object",
+				"schema": {
+					"type": "json",
+					"value": "{\"id\":{\"type\":\"string\"}}"
+				}
+			},
+			{
+				"type": "object",
+				"schema": {
+					"type": "json",
+					"value": "{\"score\":{\"type\":\"number\"}}"
+				}
+			}
+		]
+	}`
+
+	result := normalizeLegacySchemaValues([]byte(flow))
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	tasks := parsed["tasks"].([]interface{})
+	for i, raw := range tasks {
+		task := raw.(map[string]interface{})
+		schema := task["schema"].(map[string]interface{})
+		var schemaObj map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(schema["value"].(string)), &schemaObj), "task %d", i)
+		assert.Equal(t, "object", schemaObj["type"], "task %d should be wrapped", i)
+		assert.Contains(t, schemaObj, "properties", "task %d should have properties", i)
+	}
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```


**What is the current behavior?**
Older flow definitions store schema values in a legacy flat format, e.g. {"fieldName": {"type": "string"}}, instead of proper JSON Schema format. When FLOGO_SCHEMA_VALIDATION=true, these legacy schemas fail to validate correctly because the schema validator expects a standard JSON Schema structure like {"type": "object", "properties": {"fieldName": {"type": "string"}}}.

**What is the new behavior?**
Before processing a flow definition, the legacy schema values are automatically normalized into proper JSON Schema format. This ensures backward compatibility with older flow definitions while also making schema validation work correctly when FLOGO_SCHEMA_VALIDATION=true is set.