### PR TITLE
FLOGO-18450: Concurrent execution of parallel transition branches

### DIFF
--- a/action.go
+++ b/action.go
@@ -407,13 +407,20 @@ func (fa *FlowAction) Run(ctx context.Context, inputs map[string]interface{}, ha
 			handler.HandleResult(results, nil)
 		}
 
-		for hasWork && inst.Status() < model.FlowStatusCompleted && stepCount < maxStepCount {
-			stepCount++
-			logger.Debugf("Step: %d", stepCount)
-			taskStartTime := time.Now().UTC()
-			hasWork = inst.DoStep()
-			if stateRecorder != nil {
-				inst.RecordState(taskStartTime)
+		if flowsupport.GetConcurrentExecution() {
+			// Concurrent path: drain ready tasks (e.g. parallel transition branches) with a
+			// bounded worker pool. When the flag is off this block is skipped and the
+			// sequential loop below runs exactly as before (no behavioral change).
+			stepCount = inst.RunConcurrent(stepCount, maxStepCount, stateRecorder)
+		} else {
+			for hasWork && inst.Status() < model.FlowStatusCompleted && stepCount < maxStepCount {
+				stepCount++
+				logger.Debugf("Step: %d", stepCount)
+				taskStartTime := time.Now().UTC()
+				hasWork = inst.DoStep()
+				if stateRecorder != nil {
+					inst.RecordState(taskStartTime)
+				}
 			}
 		}
 		if stepCount == maxStepCount && inst.Status() != model.FlowStatusCompleted {

--- a/instance/PARALLEL_BENCHMARKS.md
+++ b/instance/PARALLEL_BENCHMARKS.md
@@ -1,0 +1,80 @@
+# FLOGO-18450 — Concurrent branch execution: benchmark & when-to-enable guide
+
+Flag: `FLOGO_FLOW_CONCURRENT_TASK_EXECUTION` (default **off**). Off = sequential `DoStep`
+loop (unchanged). On = `RunConcurrent` worker pool of `min(GOMAXPROCS, 32)` workers.
+
+**Bottom line:** keep it **off by default** (as shipped). Enable it per workload only when a
+flow has **2+ parallel branches that each do non-trivial work** — any blocking I/O
+(delay/REST/DB/messaging) or **≳ ~100 µs of CPU per branch**. There it's a **2×–7× wall-clock
+win**. Below that it's a pure tax (~90–100 µs fixed overhead/run, +12 allocs), making trivial
+or linear flows **2–3× slower**. Default-off means no existing flow regresses unless opted in.
+
+## Method
+- Machine: AMD EPYC 7763, `windows/amd64`, `GOMAXPROCS=16` (shared cloud VM — high variance).
+- `go test -run=^$ -bench=. -benchmem -benchtime=1s -count=6`, `FLOGO_LOG_LEVEL=ERROR`.
+- Each iteration builds a fresh instance + runs to completion in **both** modes (symmetric;
+  JSON parse excluded via `b.ResetTimer`). CPU work is a real integer loop with an atomic
+  sink (not optimized away). Numbers are **medians**; `[min–max]` is the speedup envelope.
+- Reproduce: `go test -run=^$ -bench='BenchmarkFlow|BenchmarkLockSetGetValue' -benchmem -benchtime=1s -count=6 github.com/project-flogo/flow/instance` (from `engine-debug`).
+
+## Results (median of 6; speedup = seq ÷ conc, >1 = concurrent faster)
+
+| Scenario | per-branch work | seq | conc | speedup | envelope |
+|---|---|---|---|---|---|
+| SeqChain8_noop (linear, no fan-out) | — | 49.7 µs | 139.5 µs | **0.36×** (slower) | 0.27–0.54× |
+| Par8_noop (8 trivial branches) | ~0 | 68.1 µs | 167.4 µs | **0.41×** (slower) | 0.31–0.63× |
+| Par8_cpu20 | ~20 µs | 230 µs | 279 µs | 0.82× (slower) | 0.57–1.37× |
+| Par8_cpu50 | ~50 µs | 512 µs | 369 µs | 1.39× (break-even) | 1.00–2.07× |
+| Par8_cpu100 | ~100 µs | 968 µs | 547 µs | **1.77×** | 1.23–2.70× |
+| Par8_cpu200 | ~200 µs | 1.59 ms | 0.77 ms | **2.07×** | 1.21–2.22× |
+| Par8_cpu1000 | ~1 ms | 8.95 ms | 2.25 ms | **3.98×** | 2.70–5.32× |
+| Par8_cpu5000 | ~5 ms | 36.7 ms | 10.8 ms | **3.39×** | 2.71–4.18× |
+| **Par8_sleep1ms (I/O-like)** | 1 ms wait | 11.9 ms | 1.77 ms | **6.72×** | 6.44–7.31× |
+| Par4_cpu1000 | ~1 ms ×4 | 3.87 ms | 1.71 ms | 2.27× | 1.39–3.94× |
+| Par16_cpu1000 | ~1 ms ×16 | 14.7 ms | 3.91 ms | 3.77× | 3.20–4.25× |
+
+**Lock micro-overhead** (`SetValue`+`GetValue`, uncontended): off 87 ns → on 128 ns =
+**~40 ns added per pair, 0 added allocs**. Negligible vs the per-run fixed cost.
+
+## What the numbers mean
+- **Lock hit is not the issue.** ~40 ns/access is dwarfed by a **fixed ~90–100 µs
+  orchestration cost per `RunConcurrent` run** (group `context.WithCancel`, `WaitGroup`,
+  `Cond`, spinning up 16 workers) — independent of branch count. Same +12 allocs / ~+0.5 KB
+  per run at every width (the one rock-stable signal).
+- **Crossover ≈ 50 µs of CPU per branch** (break-even at cpu50, worst-case 1.00×; robustly
+  faster by cpu100). Because the synthetic CPU loop is a best case (no allocs/cache misses),
+  treat **~100 µs/branch** as the practical "comfortably worth it" threshold for real
+  activities.
+- **CPU speedup is core-bounded** (~4× at width 8 on 16 vcpus — EPYC SMT, not 8× physical) and
+  **sub-linear in width** (4-wide 2.3×, 8-wide 4.0×, 16-wide 3.8×) due to the serialized
+  fan-in/join tail + oversubscription at width 16.
+- **I/O speedup is the big, robust win** (6.7× at 8×1 ms sleep, tightest variance) and scales
+  with **branch count, not cores** — blocked branches consume no CPU. This is the original
+  FLOGO-18450 motivation (delay/REST branches).
+
+## Decision table
+
+| Workload shape | Recommendation | Expected effect |
+|---|---|---|
+| Linear flow, no fan-out | **Keep OFF** | ~2.9× slower; only cost, no benefit |
+| Fan-out of trivial/instant branches | **Keep OFF** | ~2.0× slower; fixed overhead dwarfs the work |
+| Fan-out, light CPU (≲ ~50 µs/branch) | **Keep OFF** (indeterminate, leans negative) | Near break-even; not worth an uncertain few-% |
+| Fan-out, moderate–heavy CPU (≳ ~100 µs/branch) | **ENABLE** | 1.8×–4× faster, grows with work; core-bounded |
+| Fan-out with blocking I/O (delay/REST/DB) | **ENABLE** | ~7× faster, most robust; scales past GOMAXPROCS |
+| Wide fan-out (≥ GOMAXPROCS) of CPU work | **ENABLE**, expect sub-linear | Clear win but ~26% of ideal at 16-wide; leave spare cores |
+| Very high flow throughput, GC-sensitive | Enable only if timing criteria above also hold | +12 allocs/~0.5 KB per run (~+3% allocs) — not a gating factor |
+
+## Caveats
+- Ratios are ~1 significant figure on a noisy shared VM (per-cell CV 3–22%); reason in ranges.
+- The synthetic CPU loop is an optimistic best case → real crossover likely **higher**,
+  width-efficiency **lower**. The lock cost is **uncontended**; true fan-in contention shows up
+  as the serialized-tail term in width scaling.
+- `-race` was **not** run here (Windows has no CGO/C compiler); use `run_race_wsl.sh`.
+
+## Optional follow-ups
+- `benchstat` (Mann-Whitney) over the samples for confidence intervals.
+- `GOMAXPROCS` sweep to split fixed pool spin-up from per-goroutine cost.
+- Re-run with realistic allocating/logging activities (REST/transform) to validate against
+  these synthetic bounds.
+- Cheap alloc trims if ever needed (not a gating reason): reuse `cancelCtx`/`Cond`/`WaitGroup`
+  across `RunConcurrent` retry-loop turns; hoist the worker/stop closures to methods.

--- a/instance/ind_instance.go
+++ b/instance/ind_instance.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/project-flogo/core/activity"
@@ -28,22 +31,38 @@ type IndependentInstance struct {
 	*Instance
 
 	id            string
-	stepID        int
+	stepID        atomic.Int64
 	workItemQueue *support.SyncQueue //todo: change to faster non-threadsafe queue
-	wiCounter     int
+	wiCounter     atomic.Int64
 
 	trackingChanges bool
 	changeTracker   ChangeTracker
+
+	// Concurrency guards. Non-nil only when concurrent task execution is enabled
+	// (FLOGO_FLOW_CONCURRENT_TASK_EXECUTION); when nil the sequential path stays lock-free.
+	// Lock hierarchy (outer -> inner): stateLock -> attrsLock -> changeTracker lock.
+	stateLock *sync.Mutex   // guards traversal/scheduling, taskInsts/linkInsts/subflows maps, status
+	attrsLock *sync.RWMutex // guards the shared attrs and returnData maps
 
 	flowModel   *model.FlowModel
 	patch       *flowsupport.Patch
 	interceptor *coresupport.Interceptor
 
-	subflowCtr int
+	subflowCtr atomic.Int64
 	subflows   map[int]*Instance
 	startTime  time.Time
 	//Instance recorder
 	instRecorder *stateInstanceRecorder
+
+	// Concurrent-execution coordination (RunConcurrent). Zero/nil in sequential mode.
+	concurCtx        context.Context    // per-fork cancellable context handed to in-flight tasks
+	concurCancel     context.CancelFunc // cancels concurCtx on first branch failure
+	concurTerminated atomic.Bool        // set under stateLock when the master flow reaches a terminal status
+	deferErrors      atomic.Bool        // while true, HandleGlobalError latches instead of executing
+	errLatchMu       sync.Mutex         // guards the latched-error fields below
+	errLatched       bool
+	latchedErr       error
+	latchedErrInst   *Instance
 }
 
 const (
@@ -67,8 +86,11 @@ func NewIndependentInstance(instanceID string, flowURI string, flow *definition.
 	inst.Instance.goContext = ctx
 	inst.attrs = make(map[string]interface{})
 	inst.master = inst
+	if IsConcurrentTaskExcutionEnabled() {
+		inst.stateLock = &sync.Mutex{}
+		inst.attrsLock = &sync.RWMutex{}
+	}
 	inst.id = instanceID
-	inst.stepID = 0
 	inst.workItemQueue = support.NewSyncQueue()
 	inst.flowDef = flow
 	inst.flowURI = flowURI
@@ -92,16 +114,57 @@ func NewIndependentInstance(instanceID string, flowURI string, flow *definition.
 	return inst, nil
 }
 
+// lockState acquires the instance-wide state lock when concurrent execution is
+// enabled; it is a no-op in sequential mode (lock is nil). The lock lives on the
+// master IndependentInstance, so the whole flow tree (including subflows) shares one.
+func (inst *Instance) lockState() {
+	if m := inst.master; m != nil && m.stateLock != nil {
+		m.stateLock.Lock()
+	}
+}
+
+func (inst *Instance) unlockState() {
+	if m := inst.master; m != nil && m.stateLock != nil {
+		m.stateLock.Unlock()
+	}
+}
+
+// lockAttrs/unlockAttrs guard writes to the shared attrs and returnData maps.
+// rlockAttrs/runlockAttrs guard reads. No-op in sequential mode (lock is nil).
+func (inst *Instance) lockAttrs() {
+	if m := inst.master; m != nil && m.attrsLock != nil {
+		m.attrsLock.Lock()
+	}
+}
+
+func (inst *Instance) unlockAttrs() {
+	if m := inst.master; m != nil && m.attrsLock != nil {
+		m.attrsLock.Unlock()
+	}
+}
+
+func (inst *Instance) rlockAttrs() {
+	if m := inst.master; m != nil && m.attrsLock != nil {
+		m.attrsLock.RLock()
+	}
+}
+
+func (inst *Instance) runlockAttrs() {
+	if m := inst.master; m != nil && m.attrsLock != nil {
+		m.attrsLock.RUnlock()
+	}
+}
+
 func (inst *IndependentInstance) SetInstanceRecorder(stateRecorder *stateInstanceRecorder) {
 	inst.instRecorder = stateRecorder
 }
 
 func (inst *IndependentInstance) newEmbeddedInstance(taskInst *TaskInst, flowURI string, flow *definition.Definition, ctx context.Context, cancelFunc context.CancelFunc) *Instance {
-	inst.subflowCtr++
+	subflowID := int(inst.subflowCtr.Add(1))
 
 	embeddedInst := &Instance{}
 	embeddedInst.attrs = make(map[string]interface{})
-	embeddedInst.subflowId = inst.subflowCtr
+	embeddedInst.subflowId = subflowID
 	embeddedInst.master = inst
 	embeddedInst.host = taskInst
 	embeddedInst.flowDef = flow
@@ -118,12 +181,14 @@ func (inst *IndependentInstance) newEmbeddedInstance(taskInst *TaskInst, flowURI
 		embeddedInst.tracingCtx = tc
 	}
 
+	inst.lockState()
 	if inst.subflows == nil {
 		inst.subflows = make(map[int]*Instance)
 	}
 	inst.subflows[embeddedInst.subflowId] = embeddedInst
 
 	inst.changeTracker.SubflowCreated(embeddedInst)
+	inst.unlockState()
 	//inst.ChangeTracker.SubFlowChange(taskInst.flowInst.subFlowId, CtAdd, embeddedInst.subFlowId, "")
 
 	return embeddedInst
@@ -327,7 +392,7 @@ func (inst *IndependentInstance) ResetChanges() {
 
 // StepID returns the current step ID of the Flow Instance
 func (inst *IndependentInstance) StepID() int {
-	return inst.stepID
+	return int(inst.stepID.Load())
 }
 
 func (inst *IndependentInstance) DoStep() bool {
@@ -336,7 +401,7 @@ func (inst *IndependentInstance) DoStep() bool {
 
 	inst.ResetChanges()
 
-	inst.stepID++
+	inst.stepID.Add(1)
 
 	if inst.status == model.FlowStatusActive {
 
@@ -378,9 +443,9 @@ func (inst *IndependentInstance) DoStep() bool {
 
 func (inst *IndependentInstance) scheduleEval(taskInst *TaskInst) {
 
-	inst.wiCounter++
+	wiID := int(inst.wiCounter.Add(1))
 
-	workItem := NewWorkItem(inst.wiCounter, taskInst)
+	workItem := NewWorkItem(wiID, taskInst)
 	inst.logger.Debugf("Scheduling task '%s'", taskInst.task.ID())
 
 	inst.workItemQueue.Push(workItem)
@@ -413,14 +478,31 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 		}
 	}()
 
-	var err error
-	var evalResult model.EvalResult
+	evalResult, err, skipped := inst.evalTaskBehavior(behavior, taskInst)
+	if skipped {
+		return
+	}
 
+	if err != nil {
+		//taskInst.returnError = err
+		inst.handleTaskError(behavior, taskInst, err)
+		return
+	}
+
+	inst.handleEvalResult(behavior, taskInst, evalResult)
+}
+
+// evalTaskBehavior runs a task's activity evaluation (PostEval for a resumed task, or Eval,
+// optionally through a circuit breaker) and returns the eval result. The returned skipped
+// flag is true when the task was already skipped and nothing further should be done. It is
+// shared by the sequential (execTask) and concurrent (execTaskConcurrent) drivers; in the
+// concurrent driver it runs WITHOUT the state lock so branches overlap.
+func (inst *IndependentInstance) evalTaskBehavior(behavior model.TaskBehavior, taskInst *TaskInst) (evalResult model.EvalResult, err error, skipped bool) {
 	switch taskInst.status {
 	case model.TaskStatusWaiting:
 		evalResult, err = behavior.PostEval(taskInst)
 	case model.TaskStatusSkipped:
-		return
+		return model.EvalDone, nil, true
 	default:
 		if taskInst.task.CircuitBreaker() != nil {
 			// Execute task in circuit breaker
@@ -444,13 +526,13 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 			evalResult, err = behavior.Eval(taskInst)
 		}
 	}
+	return evalResult, err, false
+}
 
-	if err != nil {
-		//taskInst.returnError = err
-		inst.handleTaskError(behavior, taskInst, err)
-		return
-	}
-
+// handleEvalResult applies the outcome of a task evaluation: completing/skipping the task,
+// marking it waiting/failed, or rescheduling it to repeat. Shared by the sequential and
+// concurrent drivers; the concurrent driver calls it while holding the state lock.
+func (inst *IndependentInstance) handleEvalResult(behavior model.TaskBehavior, taskInst *TaskInst, evalResult model.EvalResult) {
 	switch evalResult {
 	case model.EvalDone:
 		//taskInst.SetStatus(model.TaskStatusDone)
@@ -478,6 +560,229 @@ func (inst *IndependentInstance) execTask(behavior model.TaskBehavior, taskInst 
 		//task needs to iterate or retry
 		inst.scheduleEval(taskInst)
 	}
+}
+
+// latchConcurrentError records the first failure observed while the concurrent worker pool
+// is running and cancels the group context so sibling branches abort. Later errors
+// (including ones triggered by that cancellation) are ignored, so the original error wins.
+func (inst *IndependentInstance) latchConcurrentError(containerInst *Instance, err error) {
+	inst.errLatchMu.Lock()
+	if !inst.errLatched {
+		inst.errLatched = true
+		inst.latchedErr = err
+		inst.latchedErrInst = containerInst
+	}
+	inst.errLatchMu.Unlock()
+
+	if inst.concurCancel != nil {
+		inst.concurCancel()
+	}
+}
+
+func (inst *IndependentInstance) errLatchedLoad() bool {
+	inst.errLatchMu.Lock()
+	defer inst.errLatchMu.Unlock()
+	return inst.errLatched
+}
+
+// takeLatchedError returns and clears any latched failure. Called after the pool drains.
+func (inst *IndependentInstance) takeLatchedError() (*Instance, error) {
+	inst.errLatchMu.Lock()
+	defer inst.errLatchMu.Unlock()
+	if !inst.errLatched {
+		return nil, nil
+	}
+	ci, err := inst.latchedErrInst, inst.latchedErr
+	inst.errLatched = false
+	inst.latchedErr = nil
+	inst.latchedErrInst = nil
+	return ci, err
+}
+
+// markTerminatedIfDone flags the run as terminated once the master flow reaches a terminal
+// status. Must be called with the state lock held.
+func (inst *IndependentInstance) markTerminatedIfDone() {
+	if inst.status >= model.FlowStatusCompleted {
+		inst.concurTerminated.Store(true)
+	}
+}
+
+// execTaskConcurrent is the concurrent-mode counterpart of execTask. The activity
+// evaluation (the slow part) runs WITHOUT the state lock so parallel branches overlap; the
+// result handling (scheduling, traversal, shared-state mutation and per-task state
+// recording) runs under the instance state lock, so it is serialized and the join task is
+// entered exactly once. The sequential execTask path is intentionally left unchanged.
+func (inst *IndependentInstance) execTaskConcurrent(behavior model.TaskBehavior, taskInst *TaskInst, stateRecorder state.Recorder, taskStartTime time.Time) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			err := fmt.Errorf("unhandled Error executing task '%s' : %v", taskInst.task.ID(), r)
+			inst.logger.Error(err)
+			if taskInst.traceContext != nil {
+				_ = trace.GetTracer().FinishTrace(taskInst.traceContext, err)
+			}
+			inst.lockState()
+			if !taskInst.flowInst.isHandlingError {
+				taskInst.appendErrorData(NewActivityEvalError(taskInst.task.Name(), "unhandled", err.Error()))
+				inst.HandleGlobalError(taskInst.flowInst, err)
+			}
+			if stateRecorder != nil {
+				_ = inst.RecordState(taskStartTime)
+			}
+			inst.markTerminatedIfDone()
+			inst.unlockState()
+		}
+	}()
+
+	// Per-task cancellable context so context-aware activities abort on sibling failure.
+	taskInst.evalCtx = inst.concurCtx
+
+	// ---- slow part: state lock NOT held, so branches run in parallel ----
+	evalResult, err, skipped := inst.evalTaskBehavior(behavior, taskInst)
+	if skipped {
+		return
+	}
+
+	// ---- fast tail: under the instance state lock ----
+	inst.lockState()
+	defer inst.unlockState()
+
+	if err != nil {
+		inst.handleTaskError(behavior, taskInst, err)
+	} else {
+		inst.handleEvalResult(behavior, taskInst, evalResult)
+	}
+
+	if stateRecorder != nil {
+		_ = inst.RecordState(taskStartTime)
+	}
+	inst.markTerminatedIfDone()
+}
+
+// RunConcurrent drains the work-item queue using a bounded worker pool so that ready tasks
+// (e.g. parallel transition branches) execute concurrently. It is used only when concurrent
+// task execution is enabled; the sequential DoStep loop is left completely untouched. The
+// returned value is the updated step count for the caller's max-step bookkeeping.
+//
+// Failure policy is drain-then-fail: the first unhandled branch error is latched and the
+// group context is cancelled so siblings abort; the pool then waits for all in-flight work
+// to return before the (single) global error handler runs.
+func (inst *IndependentInstance) RunConcurrent(stepCount, maxStepCount int, stateRecorder state.Recorder) int {
+
+	poolSize := runtime.GOMAXPROCS(0)
+	if poolSize > 32 {
+		poolSize = 32
+	}
+	if poolSize < 1 {
+		poolSize = 1
+	}
+
+	base := inst.goContext
+	if base == nil {
+		base = context.Background()
+	}
+
+	var stepCtr atomic.Int64
+	stepCtr.Store(int64(stepCount))
+	var limitHit atomic.Bool
+
+	for {
+		inst.concurTerminated.Store(false)
+		groupCtx, groupCancel := context.WithCancel(base)
+		inst.concurCtx = groupCtx
+		inst.concurCancel = groupCancel
+		inst.deferErrors.Store(true)
+
+		var wg sync.WaitGroup
+		var inFlight atomic.Int64
+		var coordMu sync.Mutex
+		cond := sync.NewCond(&coordMu)
+
+		stop := func() bool {
+			if inst.concurTerminated.Load() {
+				return true
+			}
+			if maxStepCount > 0 && stepCtr.Load() >= int64(maxStepCount) {
+				limitHit.Store(true)
+				return true
+			}
+			return inst.errLatchedLoad()
+		}
+
+		worker := func() {
+			defer wg.Done()
+			coordMu.Lock()
+			for {
+				if stop() {
+					coordMu.Unlock()
+					cond.Broadcast()
+					return
+				}
+				item, ok := inst.workItemQueue.Pop()
+				if ok {
+					inFlight.Add(1)
+					coordMu.Unlock()
+
+					workItem := item.(*WorkItem)
+					behavior := inst.flowModel.GetDefaultTaskBehavior()
+					if typeID := workItem.taskInst.task.TypeID(); typeID != "" {
+						behavior = inst.flowModel.GetTaskBehavior(typeID)
+					}
+					inst.changeTracker.WorkItemRemoved(workItem)
+					stepCtr.Add(1)
+					inst.execTaskConcurrent(behavior, workItem.taskInst, stateRecorder, time.Now().UTC())
+
+					inFlight.Add(-1)
+					coordMu.Lock()
+					cond.Broadcast()
+					continue
+				}
+				// Queue momentarily empty: if nothing is in flight we are quiescent and done;
+				// otherwise an in-flight worker may still schedule the join successor, so wait.
+				if inFlight.Load() == 0 {
+					coordMu.Unlock()
+					cond.Broadcast()
+					return
+				}
+				cond.Wait()
+			}
+		}
+
+		for i := 0; i < poolSize; i++ {
+			wg.Add(1)
+			go worker()
+		}
+		wg.Wait()
+
+		inst.deferErrors.Store(false)
+		groupCancel()
+		inst.concurCancel = nil
+		inst.concurCtx = nil
+
+		// All in-flight work has drained. Handle a latched branch failure exactly once.
+		containerInst, ferr := inst.takeLatchedError()
+		if ferr != nil {
+			inst.lockState()
+			inst.HandleGlobalError(containerInst, ferr)
+			if stateRecorder != nil {
+				_ = inst.RecordState(time.Now().UTC())
+			}
+			inst.unlockState()
+
+			// HandleGlobalError may have started an error handler that scheduled tasks;
+			// loop to drain those too. (Single-threaded here: all workers have exited.)
+			if inst.Status() < model.FlowStatusCompleted && inst.workItemQueue.Size() > 0 && !limitHit.Load() {
+				continue
+			}
+		}
+		break
+	}
+
+	final := int(stepCtr.Load())
+	if limitHit.Load() && final > maxStepCount {
+		final = maxStepCount
+	}
+	return final
 }
 
 func (inst *IndependentInstance) execTaskWithContext(ctx context.Context, cancelFunc context.CancelFunc, behavior model.TaskBehavior, taskInst *TaskInst) {
@@ -893,6 +1198,14 @@ func (inst *IndependentInstance) handleTaskCancelled(_ model.TaskBehavior, taskI
 
 // HandleGlobalError handles instance errors
 func (inst *IndependentInstance) HandleGlobalError(containerInst *Instance, err error) {
+
+	// In concurrent mode, defer global error handling until all in-flight branches have
+	// drained. RunConcurrent invokes HandleGlobalError once after wg.Wait(); here we just
+	// latch the first error and cancel sibling branches (drain-then-fail).
+	if inst.deferErrors.Load() {
+		inst.latchConcurrentError(containerInst, err)
+		return
+	}
 
 	if containerInst.isHandlingError {
 		//todo: log error information

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -131,15 +131,25 @@ func (inst *Instance) IOMetadata() *metadata.IOMetadata {
 
 func (inst *Instance) Reply(replyData map[string]interface{}, err error) {
 	if inst.resultHandler != nil {
+		inst.lockAttrs()
 		inst.returnData = replyData
+		inst.unlockAttrs()
 		inst.resultHandler.HandleResult(replyData, err)
 	}
 }
 
 func (inst *Instance) Return(returnData map[string]interface{}, err error) {
+	// forceCompletion is read in the worker tail under stateLock; returnData/returnError
+	// live in the attrsLock domain. Acquire them sequentially (not nested) to stay clear
+	// of any ordering concern.
+	inst.lockState()
 	inst.forceCompletion = true
+	inst.unlockState()
+
+	inst.lockAttrs()
 	inst.returnData = returnData
 	inst.returnError = err
+	inst.unlockAttrs()
 }
 
 func (inst *Instance) Scope() data.Scope {
@@ -151,6 +161,12 @@ func (inst *Instance) GetError() error {
 }
 
 func (inst *Instance) GetReturnData() (map[string]interface{}, error) {
+
+	// attrsLock (leaf lock) guards both the attrs read and the lazy returnData build.
+	// Deliberately does NOT take stateLock: GetReturnData is invoked from inside the
+	// change tracker, which already runs under stateLock in the worker tail.
+	inst.lockAttrs()
+	defer inst.unlockAttrs()
 
 	if inst.returnData == nil {
 
@@ -211,6 +227,9 @@ func (inst *Instance) Logger() log.Logger {
 // Instance - data.Scope Implementation
 
 func (inst *Instance) GetValue(name string) (value interface{}, exists bool) {
+	inst.rlockAttrs()
+	defer inst.runlockAttrs()
+
 	if inst.attrs != nil {
 		attr, found := inst.attrs[name]
 
@@ -227,7 +246,12 @@ func (inst *Instance) SetValue(name string, value interface{}) error {
 		inst.logger.Debugf("SetAttr - name: %s, value:%v\n", name, value)
 	}
 
+	// Guard only the shared map write with attrsLock, and release it BEFORE notifying
+	// the change tracker: SetValue must never hold attrsLock while calling into the
+	// tracker, otherwise it inverts with GetReturnData (called from within the tracker).
+	inst.lockAttrs()
 	inst.attrs[name] = value
+	inst.unlockAttrs()
 
 	if inst.master.trackingChanges {
 		inst.master.changeTracker.AttrChange(inst.subflowId, name, value)

--- a/instance/instance_ser.go
+++ b/instance/instance_ser.go
@@ -108,7 +108,7 @@ func (inst *IndependentInstance) UnmarshalJSON(d []byte) error {
 			}
 		}
 
-		inst.subflowCtr = subFlowCtr
+		inst.subflowCtr.Store(int64(subFlowCtr))
 	}
 
 	inst.workItemQueue = support.NewSyncQueue()

--- a/instance/parallel_bench_test.go
+++ b/instance/parallel_bench_test.go
@@ -1,0 +1,169 @@
+package instance_test
+
+// Benchmarks for FLOGO-18450 concurrent execution, comparing the flag OFF (sequential) vs
+// ON (concurrent worker pool). They isolate (a) the raw lock/unlock overhead added to the
+// shared scope accessors, (b) the concurrent-machinery overhead on a flow with no
+// parallelism, and (c) the speedup on parallel branches doing trivial vs CPU-bound work,
+// including fan-out width scaling. Run from engine-debug, e.g.:
+//
+//   go test -run=^$ -bench=. -benchmem -benchtime=500ms -count=5 \
+//     github.com/project-flogo/flow/instance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/project-flogo/core/support/log"
+	"github.com/project-flogo/flow/definition"
+	"github.com/project-flogo/flow/instance"
+	"github.com/project-flogo/flow/model"
+)
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func modeName(concurrent bool) string {
+	if concurrent {
+		return "conc"
+	}
+	return "seq"
+}
+
+func parseDef(tb testing.TB, defJSON string) *definition.Definition {
+	tb.Helper()
+	defRep := &definition.DefinitionRep{}
+	if err := json.Unmarshal([]byte(defJSON), defRep); err != nil {
+		tb.Fatal(err)
+	}
+	def, err := definition.NewDefinition(defRep)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return def
+}
+
+func runFlow(tb testing.TB, def *definition.Definition, concurrent bool) {
+	inst, err := instance.NewIndependentInstance("bench", "", def, nil, log.RootLogger(), context.Background())
+	if err != nil {
+		tb.Fatal(err)
+	}
+	inst.Start(nil)
+	if concurrent {
+		inst.RunConcurrent(0, 1<<30, nil)
+	} else {
+		for inst.Status() < model.FlowStatusCompleted && inst.DoStep() {
+		}
+	}
+}
+
+// forkDefBench: start fans out to `width` branches (each a single task of the given mode and
+// work amount) that all join at a counter task.
+func forkDefBench(width int, mode string, work int) string {
+	var tasks, links strings.Builder
+	tasks.WriteString(fmt.Sprintf(`{"id":"start","activity":{"ref":"%s","input":{"mode":"noop"}}}`, flowActivityRef))
+	tasks.WriteString(fmt.Sprintf(`,{"id":"join","activity":{"ref":"%s","input":{"mode":"count"}}}`, flowActivityRef))
+	lid := 1
+	for i := 0; i < width; i++ {
+		bid := fmt.Sprintf("b%d", i)
+		tasks.WriteString(fmt.Sprintf(`,{"id":"%s","activity":{"ref":"%s","input":{"mode":"%s","ms":%d}}}`, bid, flowActivityRef, mode, work))
+		links.WriteString(fmt.Sprintf(`{"id":%d,"from":"start","to":"%s","type":"label"},`, lid, bid))
+		lid++
+		links.WriteString(fmt.Sprintf(`{"id":%d,"from":"%s","to":"join","type":"label"}`, lid, bid))
+		lid++
+		if i < width-1 {
+			links.WriteString(",")
+		}
+	}
+	return fmt.Sprintf(`{"name":"forkbench","tasks":[%s],"links":[%s]}`, tasks.String(), links.String())
+}
+
+// seqChainDefBench: a linear chain start -> t0 -> t1 -> ... of `length` tasks (no fan-out).
+func seqChainDefBench(length int, mode string, work int) string {
+	var tasks, links strings.Builder
+	tasks.WriteString(fmt.Sprintf(`{"id":"start","activity":{"ref":"%s","input":{"mode":"noop"}}}`, flowActivityRef))
+	prev := "start"
+	for i := 0; i < length; i++ {
+		id := fmt.Sprintf("t%d", i)
+		tasks.WriteString(fmt.Sprintf(`,{"id":"%s","activity":{"ref":"%s","input":{"mode":"%s","ms":%d}}}`, id, flowActivityRef, mode, work))
+		links.WriteString(fmt.Sprintf(`{"id":%d,"from":"%s","to":"%s","type":"label"}`, i+1, prev, id))
+		if i < length-1 {
+			links.WriteString(",")
+		}
+		prev = id
+	}
+	return fmt.Sprintf(`{"name":"seqbench","tasks":[%s],"links":[%s]}`, tasks.String(), links.String())
+}
+
+func benchFlow(b *testing.B, defJSON string, concurrent bool) {
+	b.Setenv(concurrentFlagEnv, boolStr(concurrent))
+	def := parseDef(b, defJSON) // parse once; construct+run a fresh instance per iteration
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runFlow(b, def, concurrent)
+	}
+}
+
+// BenchmarkLockSetGetValue isolates the raw cost the feature adds to the shared scope
+// accessors: OFF => nil locks (no-op), ON => RWMutex lock/unlock per Set + Get.
+func BenchmarkLockSetGetValue(b *testing.B) {
+	for _, on := range []bool{false, true} {
+		name := "FlagOff"
+		if on {
+			name = "FlagOn"
+		}
+		b.Run(name, func(b *testing.B) {
+			b.Setenv(concurrentFlagEnv, boolStr(on))
+			def := parseDef(b, forkDefBench(1, "noop", 0))
+			inst, err := instance.NewIndependentInstance("bench", "", def, nil, log.RootLogger(), context.Background())
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = inst.SetValue("k", i)
+				_, _ = inst.GetValue("k")
+			}
+		})
+	}
+}
+
+// BenchmarkFlow compares whole-flow execution OFF vs ON across scenarios. Compare each
+// "/seq" against its "/conc" sibling.
+func BenchmarkFlow(b *testing.B) {
+	scenarios := []struct {
+		name string
+		def  string
+	}{
+		// Overhead regime (no real per-branch work): concurrency can only cost here.
+		{"SeqChain8_noop", seqChainDefBench(8, "noop", 0)}, // no parallelism at all
+		{"Par8_noop", forkDefBench(8, "noop", 0)},          // trivial branches
+		// CPU-work sweep at width 8: find the crossover where concurrency starts to pay off.
+		{"Par8_cpu20", forkDefBench(8, "cpu", 20)},     // ~20us/branch
+		{"Par8_cpu50", forkDefBench(8, "cpu", 50)},     // ~50us/branch  (pin the crossover)
+		{"Par8_cpu100", forkDefBench(8, "cpu", 100)},   // ~100us/branch (pin the crossover)
+		{"Par8_cpu200", forkDefBench(8, "cpu", 200)},   // ~200us/branch
+		{"Par8_cpu1000", forkDefBench(8, "cpu", 1000)}, // ~1ms/branch
+		{"Par8_cpu5000", forkDefBench(8, "cpu", 5000)}, // ~5ms/branch
+		// I/O-like wait (the original motivation: delay/REST branches): the big win.
+		{"Par8_sleep1ms", forkDefBench(8, "sleep", 1)},
+		// Width scaling at a fixed ~1ms/branch CPU cost.
+		{"Par4_cpu1000", forkDefBench(4, "cpu", 1000)},
+		{"Par16_cpu1000", forkDefBench(16, "cpu", 1000)},
+	}
+	for _, s := range scenarios {
+		for _, on := range []bool{false, true} {
+			b.Run(s.name+"/"+modeName(on), func(b *testing.B) {
+				benchFlow(b, s.def, on)
+			})
+		}
+	}
+}

--- a/instance/parallel_integration_test.go
+++ b/instance/parallel_integration_test.go
@@ -1,0 +1,265 @@
+package instance_test
+
+// Black-box integration tests for concurrent flow execution (FLOGO-18450). This external
+// test package can import the simple model (which imports the instance package) without an
+// import cycle, so it exercises the real RunConcurrent path end-to-end via the public API.
+//
+// All tasks use a single modern (non-legacy) activity distinguished by a "mode" input. It
+// must be modern so the activity receives the TaskInst as its context (legacy activities
+// get a LegacyCtx whose GoContext() is nil and therefore cannot be cancelled).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/project-flogo/core/activity"
+	"github.com/project-flogo/core/data"
+	"github.com/project-flogo/core/data/coerce"
+	"github.com/project-flogo/core/data/metadata"
+	"github.com/project-flogo/core/support/log"
+	"github.com/project-flogo/flow/definition"
+	"github.com/project-flogo/flow/instance"
+	"github.com/project-flogo/flow/model"
+	"github.com/project-flogo/flow/model/simple"
+	"github.com/stretchr/testify/assert"
+)
+
+const concurrentFlagEnv = "FLOGO_FLOW_CONCURRENT_TASK_EXECUTION"
+
+var (
+	joinCount      atomic.Int64
+	sleepsStarted  atomic.Int64
+	sleepsReturned atomic.Int64
+
+	flowActivityRef string
+)
+
+func init() {
+	model.RegisterDefault(simple.New())
+
+	act := &flowActivity{md: &activity.Metadata{IOMetadata: &metadata.IOMetadata{Input: map[string]data.TypedValue{
+		"mode": data.NewTypedValue(data.TypeString, ""),
+		"ms":   data.NewTypedValue(data.TypeInt, 0),
+	}}}}
+	_ = activity.Register(act) // modern registration -> non-legacy -> cancellable context
+	flowActivityRef = activity.GetRef(act)
+}
+
+// flowActivity is a single modern activity whose behavior is selected by the "mode" input:
+// noop, sleep (context-aware), count (join marker), or fail.
+type flowActivity struct{ md *activity.Metadata }
+
+func (a *flowActivity) Metadata() *activity.Metadata { return a.md }
+
+func (a *flowActivity) Eval(ctx activity.Context) (bool, error) {
+	mode, _ := coerce.ToString(ctx.GetInput("mode"))
+	switch mode {
+	case "sleep":
+		sleepsStarted.Add(1)
+		defer sleepsReturned.Add(1)
+
+		ms, _ := coerce.ToInt(ctx.GetInput("ms"))
+		d := time.Duration(ms) * time.Millisecond
+
+		gctx := ctx.GoContext()
+		if gctx == nil {
+			time.Sleep(d)
+			return true, nil
+		}
+		select {
+		case <-time.After(d):
+			return true, nil
+		case <-gctx.Done():
+			return false, gctx.Err()
+		}
+	case "count":
+		joinCount.Add(1)
+		return true, nil
+	case "fail":
+		return false, errors.New("branch failed intentionally")
+	case "wait":
+		return false, nil // not done -> EvalWait (task parked, never resumed in this test)
+	case "cpu":
+		// Busy CPU work sized by the "ms" input (reused as work units), with a sink to
+		// prevent the compiler from optimizing the loop away. Used by benchmarks.
+		work, _ := coerce.ToInt(ctx.GetInput("ms"))
+		x := 0
+		for i := 0; i < work*1000; i++ {
+			x += (i * 2654435761) & 0x7fffffff
+		}
+		cpuSink.Add(int64(x & 1))
+		return true, nil
+	default: // noop
+		return true, nil
+	}
+}
+
+// cpuSink prevents dead-code elimination of the benchmark CPU work.
+var cpuSink atomic.Int64
+
+func waitDef() string {
+	return fmt.Sprintf(`{
+  "name": "waitflow",
+  "tasks": [
+    {"id":"start","activity":{"ref":"%[1]s","input":{"mode":"noop"}}},
+    {"id":"w","activity":{"ref":"%[1]s","input":{"mode":"wait"}}}
+  ],
+  "links": [
+    {"id":1,"from":"start","to":"w","type":"label"}
+  ]
+}`, flowActivityRef)
+}
+
+// forkJoinDef: start fans out to three sleep branches that all join at a counter task.
+func forkJoinDef(branchMs int) string {
+	return fmt.Sprintf(`{
+  "name": "forkjoin",
+  "tasks": [
+    {"id":"start","activity":{"ref":"%[1]s","input":{"mode":"noop"}}},
+    {"id":"s1","activity":{"ref":"%[1]s","input":{"mode":"sleep","ms":%[2]d}}},
+    {"id":"s2","activity":{"ref":"%[1]s","input":{"mode":"sleep","ms":%[2]d}}},
+    {"id":"s3","activity":{"ref":"%[1]s","input":{"mode":"sleep","ms":%[2]d}}},
+    {"id":"join","activity":{"ref":"%[1]s","input":{"mode":"count"}}}
+  ],
+  "links": [
+    {"id":1,"from":"start","to":"s1","type":"label"},
+    {"id":2,"from":"start","to":"s2","type":"label"},
+    {"id":3,"from":"start","to":"s3","type":"label"},
+    {"id":4,"from":"s1","to":"join","type":"label"},
+    {"id":5,"from":"s2","to":"join","type":"label"},
+    {"id":6,"from":"s3","to":"join","type":"label"}
+  ]
+}`, flowActivityRef, branchMs)
+}
+
+// forkFailDef: like forkJoinDef but the middle branch fails immediately; the two long sleep
+// branches must be cancelled and drained rather than run to completion.
+func forkFailDef(branchMs int) string {
+	return fmt.Sprintf(`{
+  "name": "forkfail",
+  "tasks": [
+    {"id":"start","activity":{"ref":"%[1]s","input":{"mode":"noop"}}},
+    {"id":"s1","activity":{"ref":"%[1]s","input":{"mode":"sleep","ms":%[2]d}}},
+    {"id":"f","activity":{"ref":"%[1]s","input":{"mode":"fail"}}},
+    {"id":"s3","activity":{"ref":"%[1]s","input":{"mode":"sleep","ms":%[2]d}}},
+    {"id":"join","activity":{"ref":"%[1]s","input":{"mode":"count"}}}
+  ],
+  "links": [
+    {"id":1,"from":"start","to":"s1","type":"label"},
+    {"id":2,"from":"start","to":"f","type":"label"},
+    {"id":3,"from":"start","to":"s3","type":"label"},
+    {"id":4,"from":"s1","to":"join","type":"label"},
+    {"id":5,"from":"f","to":"join","type":"label"},
+    {"id":6,"from":"s3","to":"join","type":"label"}
+  ]
+}`, flowActivityRef, branchMs)
+}
+
+func buildInstance(t *testing.T, defJSON string, concurrent bool) *instance.IndependentInstance {
+	t.Helper()
+	if concurrent {
+		t.Setenv(concurrentFlagEnv, "true")
+	} else {
+		t.Setenv(concurrentFlagEnv, "false")
+	}
+
+	defRep := &definition.DefinitionRep{}
+	err := json.Unmarshal([]byte(defJSON), defRep)
+	assert.NoError(t, err)
+
+	def, err := definition.NewDefinition(defRep)
+	assert.NoError(t, err)
+	assert.NotNil(t, def)
+
+	inst, err := instance.NewIndependentInstance("it-"+def.Name(), "", def, nil, log.RootLogger(), context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, inst)
+	return inst
+}
+
+func resetCounters() {
+	joinCount.Store(0)
+	sleepsStarted.Store(0)
+	sleepsReturned.Store(0)
+}
+
+// TestRunConcurrentForkJoinParallel asserts the three branches overlap (wall-clock close to
+// one branch, not the sum) and the join task fires exactly once.
+func TestRunConcurrentForkJoinParallel(t *testing.T) {
+	resetCounters()
+	inst := buildInstance(t, forkJoinDef(200), true)
+	assert.True(t, inst.Start(nil))
+
+	start := time.Now()
+	inst.RunConcurrent(0, 1000000, nil)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, model.FlowStatusCompleted, inst.Status())
+	assert.Equal(t, int64(1), joinCount.Load(), "join must run exactly once")
+	assert.Equal(t, int64(3), sleepsStarted.Load(), "all three branches must run")
+	assert.Equal(t, int64(3), sleepsReturned.Load())
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"three 200ms branches should overlap (<500ms); got %v", elapsed)
+}
+
+// TestRunSequentialForkJoin asserts the sequential (flag-off) path is unchanged: branches
+// run one after another (~600ms) and the join still fires exactly once.
+func TestRunSequentialForkJoin(t *testing.T) {
+	resetCounters()
+	inst := buildInstance(t, forkJoinDef(200), false)
+	assert.True(t, inst.Start(nil))
+
+	start := time.Now()
+	for inst.Status() < model.FlowStatusCompleted {
+		if !inst.DoStep() {
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	assert.Equal(t, model.FlowStatusCompleted, inst.Status())
+	assert.Equal(t, int64(1), joinCount.Load(), "join must run exactly once")
+	assert.Equal(t, int64(3), sleepsStarted.Load())
+	assert.Greater(t, elapsed, 500*time.Millisecond,
+		"three sequential 200ms branches should take ~600ms; got %v", elapsed)
+}
+
+// TestRunConcurrentEvalWaitQuiesces covers the EvalWait result path: a task that returns
+// "not done" is parked as Waiting, and with nothing left to schedule the pool quiesces and
+// RunConcurrent returns with the flow still active (neither completed nor failed).
+func TestRunConcurrentEvalWaitQuiesces(t *testing.T) {
+	resetCounters()
+	inst := buildInstance(t, waitDef(), true)
+	assert.True(t, inst.Start(nil))
+
+	inst.RunConcurrent(0, 1000000, nil)
+
+	assert.Equal(t, model.FlowStatusActive, inst.Status(),
+		"a parked (waiting) task should leave the flow active after the pool quiesces")
+}
+
+// TestRunConcurrentDrainThenFail asserts that a failing branch fails the whole flow, the
+// join never runs, all in-flight branches drain, and the context-aware sibling sleeps are
+// cancelled early (drain-then-fail) rather than running to completion.
+func TestRunConcurrentDrainThenFail(t *testing.T) {
+	resetCounters()
+	inst := buildInstance(t, forkFailDef(2000), true)
+	assert.True(t, inst.Start(nil))
+
+	start := time.Now()
+	inst.RunConcurrent(0, 1000000, nil)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, model.FlowStatusFailed, inst.Status(), "flow must fail when a branch fails")
+	assert.Error(t, inst.GetError(), "the failure must be surfaced")
+	assert.Equal(t, int64(0), joinCount.Load(), "join must not run when a branch fails")
+	assert.Equal(t, sleepsStarted.Load(), sleepsReturned.Load(),
+		"every in-flight branch must drain (started == returned)")
+	assert.Less(t, elapsed, 1500*time.Millisecond,
+		"sibling 2s sleeps must be cancelled, not run to completion; got %v", elapsed)
+}

--- a/instance/parallel_test.go
+++ b/instance/parallel_test.go
@@ -1,0 +1,435 @@
+package instance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/project-flogo/core/support/log"
+	"github.com/project-flogo/flow/definition"
+	"github.com/project-flogo/flow/model"
+	flowSupport "github.com/project-flogo/flow/support"
+	"github.com/stretchr/testify/assert"
+)
+
+// outputDefJSON is a minimal flow definition with output metadata, used to exercise the
+// lazy returnData build in GetReturnData.
+const outputDefJSON = `{
+  "name": "OutFlow",
+  "metadata": { "output": [ {"name":"result","type":"string","value":"built"} ] },
+  "tasks": [ {"id":"LogStart","activity":{"ref":"log","input":{"message":"hi"}}} ],
+  "links": []
+}`
+
+func newInstanceFromJSON(t *testing.T, defJSON string, concurrent bool) *IndependentInstance {
+	t.Helper()
+	if concurrent {
+		t.Setenv(flowSupport.ConcurrentExecution, "true")
+	} else {
+		t.Setenv(flowSupport.ConcurrentExecution, "false")
+	}
+	defRep := &definition.DefinitionRep{}
+	err := json.Unmarshal([]byte(defJSON), defRep)
+	assert.Nil(t, err)
+	def, err := definition.NewDefinition(defRep)
+	assert.Nil(t, err)
+	inst, err := NewIndependentInstance("test-json-"+strconv.Itoa(int(rngCounter.Add(1))), "", def, nil, log.RootLogger(), context.Background())
+	assert.Nil(t, err)
+	return inst
+}
+
+// newConcurrencyTestInstance builds an IndependentInstance with the concurrency flag set
+// to the desired value, so the per-instance locks are (or are not) created accordingly.
+func newConcurrencyTestInstance(t *testing.T, concurrent bool) *IndependentInstance {
+	t.Helper()
+	if concurrent {
+		t.Setenv(flowSupport.ConcurrentExecution, "true")
+	} else {
+		t.Setenv(flowSupport.ConcurrentExecution, "false")
+	}
+	inst, err := NewIndependentInstance("test-"+strconv.Itoa(int(rngCounter.Add(1))), "", getDef(), nil, log.RootLogger(), context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, inst)
+	return inst
+}
+
+// rngCounter gives each test instance a unique id without using Math/rand or time.
+var rngCounter atomicCounter
+
+type atomicCounter struct {
+	mu sync.Mutex
+	n  int64
+}
+
+func (c *atomicCounter) Add(d int64) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.n += d
+	return c.n
+}
+
+type mockResultHandler struct {
+	data map[string]interface{}
+	err  error
+}
+
+func (m *mockResultHandler) HandleResult(d map[string]interface{}, e error) {
+	m.data = d
+	m.err = e
+}
+
+func (m *mockResultHandler) Done() {}
+
+// TestIsConcurrentTaskExcutionEnabled verifies the flag reader delegates to the support
+// env helper (single source of truth shared with the change tracker).
+func TestIsConcurrentTaskExcutionEnabled(t *testing.T) {
+	t.Setenv(flowSupport.ConcurrentExecution, "true")
+	assert.True(t, IsConcurrentTaskExcutionEnabled())
+	t.Setenv(flowSupport.ConcurrentExecution, "false")
+	assert.False(t, IsConcurrentTaskExcutionEnabled())
+}
+
+// TestConcurrencyLocksCreatedByFlag verifies the per-instance locks exist only when the
+// concurrent-execution flag is enabled (so the sequential path stays lock-free).
+func TestConcurrencyLocksCreatedByFlag(t *testing.T) {
+	off := newConcurrencyTestInstance(t, false)
+	assert.Nil(t, off.stateLock, "stateLock must be nil when concurrency is off")
+	assert.Nil(t, off.attrsLock, "attrsLock must be nil when concurrency is off")
+
+	on := newConcurrencyTestInstance(t, true)
+	assert.NotNil(t, on.stateLock, "stateLock must be set when concurrency is on")
+	assert.NotNil(t, on.attrsLock, "attrsLock must be set when concurrency is on")
+}
+
+// TestLockHelpersNoOpWhenNil ensures the lock helpers are safe no-ops in sequential mode.
+func TestLockHelpersNoOpWhenNil(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, false)
+	assert.NotPanics(t, func() {
+		inst.lockState()
+		inst.unlockState()
+		inst.lockAttrs()
+		inst.unlockAttrs()
+		inst.rlockAttrs()
+		inst.runlockAttrs()
+	})
+}
+
+// TestLockHelpersWhenEnabled ensures the lock helpers acquire and release cleanly (no
+// deadlock on repeated lock/unlock) when concurrency is enabled.
+func TestLockHelpersWhenEnabled(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	assert.NotPanics(t, func() {
+		inst.lockState()
+		inst.unlockState()
+		inst.lockState()
+		inst.unlockState()
+
+		inst.lockAttrs()
+		inst.unlockAttrs()
+		inst.rlockAttrs()
+		inst.runlockAttrs()
+	})
+}
+
+// TestLatchConcurrentError verifies first-error-wins latching, sibling cancellation, and
+// that takeLatchedError clears the latch.
+func TestLatchConcurrentError(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+
+	cancelled := false
+	inst.concurCancel = func() { cancelled = true }
+
+	err1 := errors.New("first")
+	err2 := errors.New("second")
+	ci := inst.Instance
+
+	inst.latchConcurrentError(ci, err1)
+	assert.True(t, inst.errLatchedLoad(), "error should be latched")
+	assert.True(t, cancelled, "siblings should be cancelled on first error")
+
+	// Second error is ignored; first wins.
+	inst.latchConcurrentError(ci, err2)
+
+	gotCi, gotErr := inst.takeLatchedError()
+	assert.Equal(t, ci, gotCi)
+	assert.Equal(t, err1, gotErr)
+
+	// Latch is cleared after take.
+	assert.False(t, inst.errLatchedLoad())
+	gotCi2, gotErr2 := inst.takeLatchedError()
+	assert.Nil(t, gotCi2)
+	assert.Nil(t, gotErr2)
+}
+
+// TestMarkTerminatedIfDone verifies the terminal flag flips only at a terminal status.
+func TestMarkTerminatedIfDone(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+
+	inst.status = model.FlowStatusActive
+	inst.markTerminatedIfDone()
+	assert.False(t, inst.concurTerminated.Load())
+
+	inst.status = model.FlowStatusCompleted
+	inst.markTerminatedIfDone()
+	assert.True(t, inst.concurTerminated.Load())
+}
+
+// TestHandleGlobalErrorDeferred verifies that while the pool is running, HandleGlobalError
+// latches the error instead of executing (drain-then-fail), leaving status untouched.
+func TestHandleGlobalErrorDeferred(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	inst.SetStatus(model.FlowStatusActive)
+	inst.concurCancel = func() {}
+	inst.deferErrors.Store(true)
+
+	inst.HandleGlobalError(inst.Instance, errors.New("boom"))
+
+	assert.True(t, inst.errLatchedLoad(), "deferred error should be latched")
+	assert.Equal(t, model.FlowStatusActive, inst.Status(), "status must not change while deferring")
+}
+
+// TestSetGetValueConcurrentSafe exercises the attrs lock path under concurrent writers.
+func TestSetGetValueConcurrentSafe(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	inst.SetStatus(model.FlowStatusActive)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "k" + strconv.Itoa(n)
+			_ = inst.SetValue(key, n)
+			_, _ = inst.GetValue(key)
+		}(i)
+	}
+	wg.Wait()
+
+	v, ok := inst.GetValue("k3")
+	assert.True(t, ok)
+	assert.Equal(t, 3, v)
+}
+
+// TestReturnGuarded verifies Return populates forceCompletion/returnData/returnError under
+// the locks and that GetReturnData reads them back.
+func TestReturnGuarded(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	rd := map[string]interface{}{"a": 1}
+
+	inst.Return(rd, nil)
+	assert.True(t, inst.forceCompletion)
+
+	got, err := inst.GetReturnData()
+	assert.Nil(t, err)
+	assert.Equal(t, rd, got)
+}
+
+// TestReplyGuarded verifies Reply stores returnData (under the attrs lock) and forwards to
+// the result handler.
+func TestReplyGuarded(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	h := &mockResultHandler{}
+	inst.SetResultHandler(h)
+
+	rd := map[string]interface{}{"x": 2}
+	inst.Reply(rd, nil)
+
+	assert.Equal(t, rd, h.data)
+	got, _ := inst.GetReturnData()
+	assert.Equal(t, rd, got)
+}
+
+// TestScheduleEvalAtomicCounter verifies the work-item counter increments atomically and a
+// work item is enqueued.
+func TestScheduleEvalAtomicCounter(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	task := inst.flowDef.GetTask("LogStart")
+	assert.NotNil(t, task)
+
+	ti, _ := inst.FindOrCreateTaskInst(task)
+	before := inst.wiCounter.Load()
+	inst.scheduleEval(ti)
+
+	assert.Equal(t, before+1, inst.wiCounter.Load())
+	assert.Equal(t, 1, inst.workItemQueue.Size())
+}
+
+// stubBehavior is a minimal model.TaskBehavior used to drive evalTaskBehavior /
+// handleEvalResult directly (white-box) without importing the simple model.
+type stubBehavior struct {
+	evalResult  model.EvalResult
+	evalErr     error
+	panicOnEval bool
+}
+
+func (b *stubBehavior) Enter(model.TaskContext) model.EnterResult { return model.EREval }
+func (b *stubBehavior) Eval(model.TaskContext) (model.EvalResult, error) {
+	if b.panicOnEval {
+		panic("boom in eval")
+	}
+	return b.evalResult, b.evalErr
+}
+func (b *stubBehavior) PostEval(model.TaskContext) (model.EvalResult, error) {
+	return b.evalResult, b.evalErr
+}
+func (b *stubBehavior) Done(model.TaskContext) (bool, []*model.TaskEntry, error) {
+	return true, nil, nil
+}
+func (b *stubBehavior) Skip(model.TaskContext) (bool, []*model.TaskEntry, bool) {
+	return true, nil, false
+}
+func (b *stubBehavior) Error(model.TaskContext, error) (bool, []*model.TaskEntry) {
+	return false, nil
+}
+
+// TestEvalTaskBehaviorPaths covers the shared evaluation helper: the default (Eval) path,
+// the resumed (PostEval) path, and the already-skipped short-circuit.
+func TestEvalTaskBehaviorPaths(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	task := inst.flowDef.GetTask("LogStart")
+	ti, _ := inst.FindOrCreateTaskInst(task)
+	b := &stubBehavior{evalResult: model.EvalDone}
+
+	ti.SetStatus(model.TaskStatusReady)
+	er, err, skipped := inst.evalTaskBehavior(b, ti)
+	assert.False(t, skipped)
+	assert.Nil(t, err)
+	assert.Equal(t, model.EvalDone, er)
+
+	ti.SetStatus(model.TaskStatusWaiting)
+	er, _, skipped = inst.evalTaskBehavior(b, ti)
+	assert.False(t, skipped)
+	assert.Equal(t, model.EvalDone, er)
+
+	ti.SetStatus(model.TaskStatusSkipped)
+	_, _, skipped = inst.evalTaskBehavior(b, ti)
+	assert.True(t, skipped)
+}
+
+// TestHandleEvalResultPaths covers the shared result-handling helper across all outcomes.
+func TestHandleEvalResultPaths(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	inst.SetStatus(model.FlowStatusActive)
+	b := &stubBehavior{}
+
+	ti, _ := inst.FindOrCreateTaskInst(inst.flowDef.GetTask("LogStart"))
+
+	inst.handleEvalResult(b, ti, model.EvalWait)
+	assert.Equal(t, model.TaskStatusWaiting, ti.Status())
+
+	inst.handleEvalResult(b, ti, model.EvalFail)
+	assert.Equal(t, model.TaskStatusFailed, ti.Status())
+
+	before := inst.workItemQueue.Size()
+	inst.handleEvalResult(b, ti, model.EvalRepeat)
+	assert.Equal(t, before+1, inst.workItemQueue.Size())
+
+	// EvalDone / EvalSkip both route through handleTaskDone.
+	assert.NotPanics(t, func() {
+		tiDone, _ := inst.FindOrCreateTaskInst(inst.flowDef.GetTask("LogResult"))
+		inst.handleEvalResult(b, tiDone, model.EvalDone)
+		tiSkip, _ := inst.FindOrCreateTaskInst(inst.flowDef.GetTask("LogStart"))
+		inst.handleEvalResult(b, tiSkip, model.EvalSkip)
+	})
+}
+
+// TestExecTaskConcurrentRecover covers the defensive panic-recover path in the concurrent
+// worker: a panic during evaluation is recovered, latched as a global error (deferred), and
+// the worker unwinds cleanly without leaving the state lock held.
+func TestExecTaskConcurrentRecover(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	inst.SetStatus(model.FlowStatusActive)
+	inst.concurCtx = context.Background()
+	inst.concurCancel = func() {}
+	inst.deferErrors.Store(true)
+
+	ti, _ := inst.FindOrCreateTaskInst(inst.flowDef.GetTask("LogStart"))
+	ti.SetStatus(model.TaskStatusReady)
+
+	assert.NotPanics(t, func() {
+		inst.execTaskConcurrent(&stubBehavior{panicOnEval: true}, ti, nil, time.Time{})
+	})
+	assert.True(t, inst.errLatchedLoad(), "panic must be recovered and latched as a failure")
+
+	// The state lock must have been released (re-acquire would deadlock otherwise).
+	done := make(chan struct{})
+	go func() { inst.lockState(); inst.unlockState(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("state lock was left held by the recover path")
+	}
+}
+
+// TestNewEmbeddedInstance covers subflow creation, including the locked subflows-map write
+// and the atomic subflow counter.
+func TestNewEmbeddedInstance(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	ti, _ := inst.FindOrCreateTaskInst(inst.flowDef.GetTask("LogStart"))
+
+	emb := inst.newEmbeddedInstance(ti, "", inst.flowDef, context.Background(), nil)
+	assert.NotNil(t, emb)
+	assert.Equal(t, int64(1), inst.subflowCtr.Load())
+	assert.NotNil(t, inst.subflows)
+	assert.Equal(t, emb, inst.subflows[1])
+}
+
+// TestStepID covers the StepID accessor over the atomic counter.
+func TestStepID(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	assert.Equal(t, 0, inst.StepID())
+	inst.stepID.Add(5)
+	assert.Equal(t, 5, inst.StepID())
+}
+
+// TestGetReturnDataLazyBuild covers the lazy build of returnData from flow output metadata
+// and instance attributes.
+func TestGetReturnDataLazyBuild(t *testing.T) {
+	inst := newInstanceFromJSON(t, outputDefJSON, true)
+	// Set the attr to exercise the "attr exists" branch; the declared output default then
+	// overrides it, exercising the value-override branch too.
+	_ = inst.SetValue("result", "ok")
+
+	rd, err := inst.GetReturnData()
+	assert.Nil(t, err)
+	assert.NotNil(t, rd)
+	assert.Equal(t, "built", rd["result"])
+}
+
+// TestSetValueTracksChanges covers the change-tracking branch of SetValue (active when
+// state recording is enabled).
+func TestSetValueTracksChanges(t *testing.T) {
+	t.Setenv("FLOGO_FLOW_SM_ENDPOINT", "http://localhost:9999")
+	inst := newConcurrencyTestInstance(t, true)
+	assert.True(t, inst.trackingChanges)
+
+	inst.SetStatus(model.FlowStatusActive)
+	err := inst.SetValue("tracked", "yes")
+	assert.Nil(t, err)
+
+	v, ok := inst.GetValue("tracked")
+	assert.True(t, ok)
+	assert.Equal(t, "yes", v)
+}
+
+// TestGoContextEvalCtxOverride verifies the per-task context override used for branch
+// cancellation, falling back to the flow context when unset.
+func TestGoContextEvalCtxOverride(t *testing.T) {
+	inst := newConcurrencyTestInstance(t, true)
+	task := inst.flowDef.GetTask("LogStart")
+	ti, _ := inst.FindOrCreateTaskInst(task)
+
+	// Default: falls back to the flow goContext.
+	assert.Equal(t, inst.goContext, ti.GoContext())
+	assert.Equal(t, inst.goContext, ti.GetGoContext())
+
+	type ctxKey string
+	override := context.WithValue(context.Background(), ctxKey("k"), "v")
+	ti.evalCtx = override
+	assert.Equal(t, override, ti.GoContext())
+	assert.Equal(t, override, ti.GetGoContext())
+}

--- a/instance/taskinst.go
+++ b/instance/taskinst.go
@@ -87,6 +87,11 @@ type TaskInst struct {
 	returnError  error
 	traceContext trace.TracingContext
 
+	// evalCtx, when non-nil, overrides the flow-level GoContext for this task's activity
+	// evaluation. The concurrent scheduler sets it to a per-fork cancellable context so
+	// context-aware activities abort when a sibling branch fails. nil in sequential mode.
+	evalCtx context.Context
+
 	//needed for serialization
 	taskID string
 }
@@ -164,6 +169,9 @@ func (ti *TaskInst) GetTracingContext() trace.TracingContext {
 }
 
 func (ti *TaskInst) GoContext() context.Context {
+	if ti.evalCtx != nil {
+		return ti.evalCtx
+	}
 	return ti.flowInst.goContext
 }
 
@@ -226,6 +234,9 @@ func (ti *TaskInst) FlowLogger() log.Logger {
 }
 
 func (ti *TaskInst) GetGoContext() context.Context {
+	if ti.evalCtx != nil {
+		return ti.evalCtx
+	}
 	return ti.flowInst.goContext
 
 }

--- a/instance/taskinst_test.go
+++ b/instance/taskinst_test.go
@@ -19,7 +19,7 @@ func TestTaskInst(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	assert.NotNil(t, taskInst)
 	assert.True(t, taskInst.HasActivity())
@@ -44,7 +44,7 @@ func TestGetErrorObject_WithLinkExprError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	linkErr := definition.NewLinkExprError("link expression evaluation failed")
 
@@ -62,7 +62,7 @@ func TestGetErrorObject_WithActivityError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	errorData := map[string]interface{}{
 		"field": "value",
@@ -88,7 +88,7 @@ func TestGetErrorObject_WithActivityEvalError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	evalErr := NewActivityEvalError("LogStart", "mapper", "mapper execution failed")
 
@@ -107,7 +107,7 @@ func TestGetErrorObject_WithGenericError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	genericErr := errors.New("unexpected error occurred")
 
@@ -131,7 +131,7 @@ func TestGetErrorObject_WithRealSchemaValidationError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	schemaDef := &schema.Def{
 		Type:  "json",
@@ -177,7 +177,7 @@ func TestGetErrorObject_WithNumError(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	numErr := &strconv.NumError{
 		Func: "Atoi",
@@ -200,7 +200,7 @@ func TestGetErrorObject_WithNumErrorRange(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	numErr := &strconv.NumError{
 		Func: "ParseInt",
@@ -221,7 +221,7 @@ func TestGetErrorObject_StructureValidation(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	testCases := []struct {
 		name  string
@@ -256,7 +256,7 @@ func TestGetErrorObject_ActivityErrorWithoutActivityName(t *testing.T) {
 	def := getDef()
 	ind, _ := NewIndependentInstance("test", "", def, nil, log.RootLogger(), context.Background())
 	flowInst := &Instance{master: ind}
-	taskInst := NewTaskInst(flowInst, def.Tasks()[0])
+	taskInst := NewTaskInst(flowInst, def.GetTask("LogStart"))
 
 	errorData := map[string]interface{}{"reason": "timeout"}
 	actErr := activity.NewError("timeout error", "TIMEOUT-001", errorData)

--- a/instance/util.go
+++ b/instance/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -479,5 +478,5 @@ func StartDetachedSubFlow(ctx activity.Context, flowURI string, inputs map[strin
 }
 
 func IsConcurrentTaskExcutionEnabled() bool {
-	return os.Getenv("FLOGO_FLOW_CONCURRENT_TASK_EXECUTION") == "true"
+	return flowSupport.GetConcurrentExecution()
 }

--- a/support/env.go
+++ b/support/env.go
@@ -18,6 +18,9 @@ const (
 
 	PrioritizeExprLink             = "FLOGO_TASK_PRIORITIZE_EXPR_LINK"
 	PrioritizeExprLinkDefault bool = false
+
+	ConcurrentExecution             = "FLOGO_FLOW_CONCURRENT_TASK_EXECUTION"
+	ConcurrentExecutionDefault bool = false
 )
 
 var username, hostName, appName, appVersion string
@@ -89,4 +92,19 @@ func GetPrioritizeExprTask() bool {
 		return PrioritizeExprLinkDefault
 	}
 	return prioritizeExpression
+}
+
+// GetConcurrentExecution reports whether parallel (concurrent) execution of
+// ready tasks/branches is enabled. Default is false (sequential). Controlled by
+// the FLOGO_FLOW_CONCURRENT_TASK_EXECUTION environment variable.
+func GetConcurrentExecution() bool {
+	v, ok := os.LookupEnv(ConcurrentExecution)
+	if !ok {
+		return ConcurrentExecutionDefault
+	}
+	concurrentExecution, err := coerce.ToBool(v)
+	if err != nil {
+		return ConcurrentExecutionDefault
+	}
+	return concurrentExecution
 }

--- a/support/env_test.go
+++ b/support/env_test.go
@@ -1,0 +1,36 @@
+package support
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetConcurrentExecution covers every branch of the env-flag helper: unset (default),
+// truthy, falsey, and an unparseable value (which falls back to the default).
+func TestGetConcurrentExecution(t *testing.T) {
+	orig, had := os.LookupEnv(ConcurrentExecution)
+	defer func() {
+		if had {
+			_ = os.Setenv(ConcurrentExecution, orig)
+		} else {
+			_ = os.Unsetenv(ConcurrentExecution)
+		}
+	}()
+
+	_ = os.Unsetenv(ConcurrentExecution)
+	assert.False(t, GetConcurrentExecution(), "unset must default to false")
+
+	_ = os.Setenv(ConcurrentExecution, "true")
+	assert.True(t, GetConcurrentExecution())
+
+	_ = os.Setenv(ConcurrentExecution, "1")
+	assert.True(t, GetConcurrentExecution(), "coerce should accept 1 as true")
+
+	_ = os.Setenv(ConcurrentExecution, "false")
+	assert.False(t, GetConcurrentExecution())
+
+	_ = os.Setenv(ConcurrentExecution, "not-a-bool")
+	assert.False(t, GetConcurrentExecution(), "unparseable value must default to false")
+}


### PR DESCRIPTION
## What
Adds opt-in **concurrent execution of activities on parallel transition branches** in the flow action (FLOGO-18450). Branches the flow models as parallel now actually run concurrently instead of the worker draining one activity at a time.

## Why
The flow action drains ready work items sequentially, so independent parallel branches serialize — total latency ≈ the *sum* of branch times. Running them concurrently makes it ≈ the *slowest* branch (dramatically so for I/O-bound branches such as delay/REST/DB).

## Design & safety
- Gated behind the existing `FLOGO_FLOW_CONCURRENT_TASK_EXECUTION` env flag, **default off**. When off, the sequential `DoStep` loop is byte-for-byte unchanged — **no existing flow regresses unless explicitly opted in**.
- When on, `FlowAction.Run` drives a new `IndependentInstance.RunConcurrent` worker pool (`min(GOMAXPROCS, 32)` workers) that executes ready tasks concurrently.
- **Join preserved**: a task runs only after all its incoming links resolve; the set-link → check-readiness → enter-join sequence is one critical section, so the join fires exactly once.
- **Two-lock design** (both `nil` in sequential mode): a coarse `stateLock` (traversal/scheduling, `taskInsts`/`linkInsts`/`subflows`) plus an `attrsLock` RWMutex (shared scope + `returnData`). Strict order `stateLock → changeTracker → attrsLock`. `stepID`/`wiCounter`/`subflowCtr` promoted to atomics.
- **Drain-then-fail**: the first unhandled branch error cancels siblings via a per-task cancellable context (`TaskInst.evalCtx`), the pool waits for in-flight branches to return, then the global error handler fires exactly once.
- `execTask` and the new `execTaskConcurrent` share extracted `evalTaskBehavior` + `handleEvalResult` helpers (removes duplication; sequential behavior unchanged).

## Testing
- Unit + integration tests: parallelism (wall-clock), join-fires-once, drain-then-fail with real cancellation, and sequential parity. **~87% coverage of the new code.**
- **Clean under `go test -race`** (`-count=1` full package + `-count=10` stress on the concurrent tests).
- Fixed pre-existing map-order-flaky `TestGetErrorObject_*` (`def.Tasks()[0]` → `def.GetTask("LogStart")`; `Definition.Tasks()` iterates a map).

## Performance — when to enable
Full data + methodology in `instance/PARALLEL_BENCHMARKS.md`. Bottom line (16-core EPYC, medians):
- Lock overhead is negligible (~40 ns/access, 0 added allocs); the real cost is a fixed **~90–100 µs orchestration per run** (+12 allocs).
- **Crossover ≈ 50–100 µs of work per branch.** Below it concurrency is 2–3× *slower* (pure overhead); above it ~2–4× faster for CPU-bound branches and **~7× faster for I/O-bound** (delay/REST) branches.
- Recommendation: enable per-flow only for **2+ branches each doing blocking I/O or ≳ ~100 µs of CPU**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
